### PR TITLE
Fix duplicate package_builder subclass in developer_platform

### DIFF
--- a/developer_platform/package_builder.py
+++ b/developer_platform/package_builder.py
@@ -3,12 +3,7 @@ Package Builder for YasinAI Developer Platform.
 Bundles modules, agents, and plugins into deployable artifacts.
 """
 
-from yasinai.deployment.package_builder import PackageBuilder as DeploymentPackageBuilder
+from yasinai.deployment.package_builder import PackageBuilder
 
-
-class PackageBuilder(DeploymentPackageBuilder):
-    """
-    Manages packaging of plugins, agents, and platform integrations for distribution.
-    Shared with the Deployment System.
-    """
-    pass
+# Thin re-export to keep backwards compatibility without redundant subclassing.
+__all__ = ["PackageBuilder"]


### PR DESCRIPTION
This PR removes duplicate code by replacing the empty subclass in `developer_platform/package_builder.py` with a thin re-export of `PackageBuilder` from `yasinai.deployment.package_builder`. This ensures all public import paths continue to work without breaks while resolving duplicate code.

---
*PR created automatically by Jules for task [10866156653532322938](https://jules.google.com/task/10866156653532322938) started by @yusi20006-max*