### PR TITLE
Add GitHub Actions workflow for Docker build and smoke test

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,28 @@
+name: Docker Build & Smoke Test
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    name: Build and Smoke Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Workaround pyproject.toml setuptools flat-layout discovery
+        run: |
+          echo -e '\n[tool.setuptools]\npackages = ["yasinai", "yasinai.core", "yasinai.cli", "yasinai.deployment", "security_platform", "developer_platform", "knowledge_platform"]' >> pyproject.toml
+
+      - name: Build Docker Image
+        run: |
+          docker build -t yasinai:latest .
+
+      - name: Run Smoke Test
+        run: |
+          docker run --rm yasinai:latest yasin status


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to build the project's Docker image and run a smoke test (`yasin status`) inside the container. It triggers on pushes to main and manual dispatch (workflow_dispatch). To allow the Docker image to build successfully without modifying any other files in the repository (e.g. pyproject.toml), the workflow applies a temporary setuptools configuration patch inside the runner before running `docker build`.

---
*PR created automatically by Jules for task [5239863573869572163](https://jules.google.com/task/5239863573869572163) started by @yusi20006-max*