### PR TITLE
Add yasin serve CLI subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,17 @@ yasin security check [--json]
 
 # Build deployment artifacts and packages
 yasin package build --output [directory] --version [version] [--json]
+
+# Keep Core Runtime alive as a long-running foreground supervisor
+yasin serve [--interval SECONDS] [--json]
 ```
 
 #### Detailed CLI Commands and Options:
 
 *   **`yasin status`**: Orchestrates the Core Runtime, boots the services and displays environment/runtime diagnostics.
+*   **`yasin serve`**: Launches the Core Runtime in foreground supervisor mode, performing periodic health checks.
+    *   `--interval`: Periodic health check interval in seconds (defaults to `300` / 5 minutes).
+    *   `--json`: Consistent with the global flag, logs status updates and health check reports as JSON lines.
 *   **`yasin agent create`**: Scaffolds a new agent using the `AgentSDK`.
     *   `[name]`: Positional argument (defaults to `default_agent`).
     *   `--role`: Role of the agent (e.g. `general`, `security`, `knowledge`; defaults to `general`).
@@ -99,6 +105,23 @@ yasin package build --output [directory] --version [version] [--json]
 *   **`yasin package build`**: Triggers `PackageBuilder` to build deployable artifacts.
     *   `--output`: Target directory (defaults to `dist/`).
     *   `--version`: Target release version (defaults to `1.0.0`).
+
+### Android Termux & background keeping
+
+For maintaining the YasinAI Core Runtime long-running on Android devices using **Termux**, you can use **tmux** combined with `termux-wake-lock` to prevent the OS from killing or putting the CPU to sleep:
+
+```bash
+# Acquire Termux Wake Lock to keep CPU active
+termux-wake-lock
+
+# Start or attach to a tmux session
+tmux new -s yasin-session
+
+# Run the long-running foregound YasinAI supervisor with a custom health check interval (e.g. 5 minutes)
+yasin serve --interval 300
+```
+
+To detach from the tmux session and keep it running in the background, press `Ctrl+B` then `D`.
 
 ### Development Rules (summary)
 
@@ -190,11 +213,17 @@ yasin security check [--json]
 
 # ساخت بسته‌ها و محصولات استقرار
 yasin package build --output [directory] --version [version] [--json]
+
+# زنده نگه داشتن هسته اجرایی YasinAI به عنوان ناظر پیش زمینه
+yasin serve [--interval SECONDS] [--json]
 ```
 
 #### جزئیات دستورات و گزینه‌های خط فرمان:
 
 *   **`yasin status`**: هسته اجرایی را لود و مدیریت کرده و عیب‌یابی‌ها و جزییات وضعیت سیستم را نمایش می‌دهد.
+*   **`yasin serve`**: هسته اجرایی را در حالت ناظر پیش‌زمینه به همراه بررسی‌های دوره‌ای سلامت آغاز می‌کند.
+    *   `--interval`: دوره زمانی بررسی‌های سلامت بر حسب ثانیه (پیش‌فرض: `300` ثانیه یا ۵ دقیقه).
+    *   `--json`: خروجی گزارش‌ها و رویدادها را به صورت خطوط JSON تولید می‌کند.
 *   **`yasin agent create`**: یک عامل جدید مبتنی بر `AgentSDK` ایجاد می‌کند.
     *   `[name]`: آرگومان موقعیتی نام عامل (به طور پیش‌فرض `default_agent`).
     *   `--role`: نقش عامل (مانند `general`, `security`, `knowledge`؛ پیش‌فرض: `general`).
@@ -208,6 +237,23 @@ yasin package build --output [directory] --version [version] [--json]
 *   **`yasin package build`**: پکیج استقرار را از طریق `PackageBuilder` آماده می‌سازد.
     *   `--output`: دایرکتوری خروجی (پیش‌فرض: `dist/`).
     *   `--version`: نسخه هدف پکیج (پیش‌فرض: `1.0.0`).
+
+### استفاده در اندروید (Termux) و زنده نگه‌داشتن فرآیند
+
+برای اجرای مداوم و طولانی‌مدت هسته اجرایی YasinAI در سیستم‌عامل اندروید با استفاده از **Termux**، می‌توانید از **tmux** و ابزار `termux-wake-lock` برای جلوگیری از خواب رفتن CPU یا بسته شدن فرآیند توسط سیستم‌عامل استفاده کنید:
+
+```bash
+# فعال‌سازی قفل بیدارباش Termux برای فعال نگه‌داشتن پردازنده
+termux-wake-lock
+
+# ایجاد یا متصل شدن به یک جلسه tmux
+tmux new -s yasin-session
+
+# اجرای دستور سرویس پیش‌زمینه YasinAI با بازه زمانی دلخواه (مثلاً ۵ دقیقه)
+yasin serve --interval 300
+```
+
+برای خروج موقت (Detach) از جلسه tmux بدون توقف فرآیند، کلیدهای `Ctrl+B` و سپس `D` را فشار دهید.
 
 ### قوانین توسعه (خلاصه)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,114 @@ def test_create_parser():
     assert "memory" in choices
     assert "security" in choices
     assert "package" in choices
+    assert "serve" in choices
+
+
+# Test 'serve' subcommand parser options
+def test_serve_parser_options():
+    parser = create_parser()
+    args = parser.parse_args(["serve", "--interval", "10", "--json"])
+    assert args.command == "serve"
+    assert args.interval == 10
+    assert args.json is True
+
+
+def test_handle_serve_invalid_interval(capsys):
+    from yasinai.cli.main import handle_serve
+    args = argparse.Namespace(interval=0, json=False)
+    exit_code = handle_serve(args)
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Error: Interval must be a positive integer." in captured.err
+
+
+@patch("time.sleep")
+@patch("yasinai.deployment.health_check.HealthCheck.run_all_checks")
+def test_serve_command_loop(mock_run_all, mock_sleep, capsys):
+    import os
+    import signal
+    from yasinai.cli.main import handle_serve
+    mock_run_all.return_value = {"success": True, "status": "HEALTHY"}
+    args = argparse.Namespace(interval=5, json=False)
+
+    # Simulate SIGINT signal inside time.sleep
+    def sleep_side_effect(secs):
+        os.kill(os.getpid(), signal.SIGINT)
+
+    mock_sleep.side_effect = sleep_side_effect
+
+    exit_code = handle_serve(args)
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "YasinAI Foreground Serve" in captured.out
+    assert "YasinAI Core Runtime started in foreground supervisor mode" in captured.out
+    assert "Health Check Status: HEALTHY" in captured.out
+    assert "Shutting down YasinAI Core Runtime cleanly..." in captured.out
+
+
+@patch("time.sleep")
+@patch("yasinai.deployment.health_check.HealthCheck.run_all_checks")
+def test_serve_command_json_output(mock_run_all, mock_sleep, capsys):
+    import os
+    import signal
+    from yasinai.cli.main import handle_serve
+    mock_run_all.return_value = {"success": True, "status": "HEALTHY"}
+    args = argparse.Namespace(interval=1, json=True)
+
+    # Simulate SIGTERM signal inside time.sleep
+    def sleep_side_effect(secs):
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    mock_sleep.side_effect = sleep_side_effect
+
+    exit_code = handle_serve(args)
+    assert exit_code == 0
+    captured = capsys.readouterr()
+
+    lines = [json.loads(line) for line in captured.out.strip().split("\n")]
+    assert len(lines) >= 3
+    assert lines[0]["event"] == "startup"
+    assert lines[0]["status"] == "running"
+    assert lines[1]["event"] == "health_check"
+    assert lines[1]["status"] == "HEALTHY"
+    assert lines[1]["success"] is True
+    assert lines[-1]["event"] == "shutdown"
+    assert lines[-1]["status"] == "stopped"
+
+
+@patch("time.sleep")
+@patch("yasinai.deployment.health_check.HealthCheck.run_all_checks")
+def test_serve_command_graceful_shutdown(mock_run_all, mock_sleep, capsys):
+    import os
+    import signal
+    from yasinai.cli.main import handle_serve
+    mock_run_all.return_value = {"success": False, "status": "DEGRADED"}
+    args = argparse.Namespace(interval=5, json=False)
+
+    def sleep_side_effect(secs):
+        os.kill(os.getpid(), signal.SIGINT)
+
+    mock_sleep.side_effect = sleep_side_effect
+
+    exit_code = handle_serve(args)
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Health Check Status: DEGRADED" in captured.out
+    assert "Shutting down YasinAI Core Runtime cleanly..." in captured.out
+
+
+def test_handle_serve_exception_path(capsys):
+    from yasinai.cli.main import handle_serve
+    args = argparse.Namespace(interval=5, json=False)
+    with patch("yasinai.cli.main.Runtime") as mock_runtime_class:
+        mock_instance = MagicMock()
+        mock_instance.start.side_effect = Exception("Runtime startup failure")
+        mock_runtime_class.return_value = mock_instance
+
+        exit_code = handle_serve(args)
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert "Error in serve loop: Runtime startup failure" in captured.err
 
 
 # Test 'status' handler (text and JSON mode)

--- a/yasinai/cli/main.py
+++ b/yasinai/cli/main.py
@@ -234,6 +234,107 @@ def handle_package_build(args: argparse.Namespace) -> int:
         return 1
 
 
+def handle_serve(args: argparse.Namespace) -> int:
+    """
+    Handle the 'yasin serve' command.
+    Keeps the YasinAI runtime alive as a long-running foreground supervisor loop,
+    performing periodic health checks.
+    """
+    import signal
+    import time
+    from yasinai.deployment.health_check import HealthCheck
+
+    logger.debug("Executing CLI command: serve")
+    interval: int = getattr(args, "interval", 300)
+
+    # Validate interval
+    if interval <= 0:
+        logger.error("Interval must be a positive integer.")
+        print("Error: Interval must be a positive integer.", file=sys.stderr)
+        return 1
+
+    runtime = Runtime()
+    stop_flag = False
+
+    def signal_handler(signum, frame):
+        nonlocal stop_flag
+        stop_flag = True
+
+    # Register signal handlers
+    original_sigint = signal.getsignal(signal.SIGINT)
+    original_sigterm = signal.getsignal(signal.SIGTERM)
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        runtime.start()
+
+        health_checker = HealthCheck()
+
+        startup_msg = f"YasinAI Core Runtime started in foreground supervisor mode. Health check interval: {interval} seconds."
+        if args.json:
+            print(json.dumps({
+                "event": "startup",
+                "status": "running",
+                "interval": interval,
+                "message": startup_msg
+            }))
+        else:
+            print("=========================================")
+            print("         YasinAI Foreground Serve        ")
+            print("=========================================")
+            print(startup_msg)
+            print("Press Ctrl+C to stop.")
+            print("=========================================")
+        logger.info(startup_msg)
+
+        while not stop_flag:
+            report = health_checker.run_all_checks()
+
+            if args.json:
+                print(json.dumps({
+                    "event": "health_check",
+                    "status": report.get("status"),
+                    "success": report.get("success"),
+                    "timestamp": time.strftime('%Y-%m-%d %H:%M:%S')
+                }))
+            else:
+                timestamp = time.strftime('%Y-%m-%d %H:%M:%S')
+                print(f"[{timestamp}] Health Check Status: {report.get('status')} (Success: {report.get('success')})")
+
+            logger.info(f"Health Check Completed: {report}")
+
+            # Sleep in small increments to be responsive to signals
+            slept = 0
+            while slept < interval and not stop_flag:
+                time.sleep(1)
+                slept += 1
+
+    except Exception as e:
+        logger.error(f"Error in serve loop: {e}", exc_info=True)
+        print(f"Error in serve loop: {e}", file=sys.stderr)
+        return 1
+    finally:
+        # Restore signal handlers
+        signal.signal(signal.SIGINT, original_sigint)
+        signal.signal(signal.SIGTERM, original_sigterm)
+
+        shutdown_msg = "Shutting down YasinAI Core Runtime cleanly..."
+        if args.json:
+            print(json.dumps({
+                "event": "shutdown",
+                "status": "stopped",
+                "message": shutdown_msg
+            }))
+        else:
+            print(shutdown_msg)
+        logger.info(shutdown_msg)
+
+        runtime.shutdown()
+
+    return 0
+
+
 def create_parser() -> argparse.ArgumentParser:
     """
     Creates and configures the argument parser for YasinAI CLI.
@@ -290,6 +391,11 @@ def create_parser() -> argparse.ArgumentParser:
     package_build_parser.add_argument("--output", default="dist/", help="Output directory")
     package_build_parser.add_argument("--version", default="1.0.0", help="Target package version")
     package_build_parser.set_defaults(func=handle_package_build)
+
+    # 6. 'serve' command
+    serve_parser = subparsers.add_parser("serve", help="Keep Core Runtime alive as a foreground process", parents=[parent_parser])
+    serve_parser.add_argument("--interval", type=int, default=300, help="Periodic health-check interval in seconds")
+    serve_parser.set_defaults(func=handle_serve)
 
     return parser
 


### PR DESCRIPTION
This change adds the `yasin serve` subcommand to the YasinAI CLI. It launches the Core Runtime as a long-running foreground supervisor, running periodic health checks at a configurable interval (defaulting to 300 seconds) and outputting status reports as standard logs or JSON lines. It handles SIGINT and SIGTERM gracefully, exiting with status 0. Extensive unit tests have been added to tests/test_cli.py, and both English and Persian sections in README.md have been updated with Termux tmux + wake-lock patterns.

---
*PR created automatically by Jules for task [3582807012516260826](https://jules.google.com/task/3582807012516260826) started by @yusi20006-max*