### PR TITLE
test: establish Phase 3 test infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,18 @@ yasin = "yasinai.cli.security_entrypoint:main"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+testpaths = ["tests"]
+addopts = ["-ra", "--strict-markers"]
+
+[tool.coverage.run]
+branch = true
+source = ["yasinai", "security_platform", "developer_platform", "knowledge_platform"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+exclude_also = [
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]
+show_missing = true
+skip_covered = false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest-cov==7.0.0

--- a/tests/test_encryption_regression.py
+++ b/tests/test_encryption_regression.py
@@ -1,0 +1,43 @@
+"""Regression tests for the AES-256-GCM encryption contract."""
+
+import base64
+
+import pytest
+
+from security_platform.encryption import EncryptionEngine
+
+
+def test_encryption_uses_expected_serialized_layout() -> None:
+    key = EncryptionEngine.generate_key()
+    ciphertext = EncryptionEngine.encrypt("secret", key)
+    raw = base64.b64decode(ciphertext, validate=True)
+
+    # salt + 96-bit nonce + AES-GCM authentication tag
+    assert len(raw) >= EncryptionEngine.SALT_SIZE + EncryptionEngine.NONCE_SIZE + 16
+    assert EncryptionEngine.decrypt(ciphertext, key) == "secret"
+
+
+def test_encryption_is_nondeterministic() -> None:
+    key = EncryptionEngine.generate_key()
+
+    first = EncryptionEngine.encrypt("same plaintext", key)
+    second = EncryptionEngine.encrypt("same plaintext", key)
+
+    assert first != second
+    assert EncryptionEngine.decrypt(first, key) == "same plaintext"
+    assert EncryptionEngine.decrypt(second, key) == "same plaintext"
+
+
+def test_tampering_fails_authentication() -> None:
+    key = EncryptionEngine.generate_key()
+    raw = bytearray(base64.b64decode(EncryptionEngine.encrypt("secret", key), validate=True))
+    raw[-1] ^= 0x01
+
+    tampered = base64.b64encode(raw).decode("ascii")
+    with pytest.raises(ValueError, match="authentication tag mismatch"):
+        EncryptionEngine.decrypt(tampered, key)
+
+
+def test_invalid_ciphertext_encoding_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Invalid ciphertext encoding"):
+        EncryptionEngine.decrypt("not-base64!!!", EncryptionEngine.generate_key())

--- a/tests/test_security_scanner.py
+++ b/tests/test_security_scanner.py
@@ -1,35 +1,79 @@
+"""Tests for the deterministic repository security scanner."""
+
 from pathlib import Path
 
 from security_platform.scanner import SecurityScanner
 
 
+def _policy_files(root: Path) -> None:
+    (root / ".gitignore").write_text(".env\n*.key\n*.pem\n*.token\n", encoding="utf-8")
+    (root / "SECURITY_TRUTH.md").write_text("security truth", encoding="utf-8")
+    (root / "AGENTS.md").write_text("engineering policy", encoding="utf-8")
+
+
+def test_scanner_clean_repository(tmp_path: Path) -> None:
+    _policy_files(tmp_path)
+    (tmp_path / "config.py").write_text("VALUE = 'safe'\n", encoding="utf-8")
+
+    report = SecurityScanner(tmp_path).scan()
+
+    assert report["status"] == "SECURE"
+    assert report["failed_items"] == 0
+    assert report["scanned_items"] >= 5
+
+
 def test_secret_scan_detects_private_key(tmp_path: Path) -> None:
-    (tmp_path / ".gitignore").write_text(".env\n*.key\n*.pem\n*.token\n", encoding="utf-8")
+    _policy_files(tmp_path)
     marker = "-----BEGIN " + "PRIVATE KEY-----"
     (tmp_path / "sample.py").write_text(f"PRIVATE = {marker!r}\n", encoding="utf-8")
+
     report = SecurityScanner(tmp_path).scan()
+
     assert report["status"] == "VULNERABLE"
-    assert any(item["id"] == "SEC_SECRET_001" and not item["passed"] for item in report["findings"])
+    findings = [item for item in report["findings"] if item["id"] == "SEC_SECRET_001"]
+    assert findings and findings[0]["passed"] is False
+    assert findings[0]["severity"] == "critical"
+    assert findings[0]["path"] == "sample.py"
 
 
 def test_secret_policy_requires_common_patterns(tmp_path: Path) -> None:
     (tmp_path / ".gitignore").write_text(".env\n", encoding="utf-8")
+
     finding = SecurityScanner(tmp_path).check_secret_policy()
+
     assert finding.passed is False
     assert "*.key" in finding.details
 
 
 def test_scanner_accepts_complete_secret_policy(tmp_path: Path) -> None:
-    (tmp_path / ".gitignore").write_text(".env\n*.key\n*.pem\n*.token\n", encoding="utf-8")
-    (tmp_path / "SECURITY_TRUTH.md").write_text("security truth", encoding="utf-8")
-    (tmp_path / "AGENTS.md").write_text("policy", encoding="utf-8")
+    _policy_files(tmp_path)
     scanner = SecurityScanner(tmp_path)
+
     assert scanner.check_secret_policy().passed is True
     assert scanner.check_policy_files().passed is True
 
 
 def test_world_writable_file_is_rejected(tmp_path: Path) -> None:
-    (tmp_path / "sample.py").write_text("print('x')", encoding="utf-8")
-    (tmp_path / "sample.py").chmod(0o666)
+    _policy_files(tmp_path)
+    source = tmp_path / "sample.py"
+    source.write_text("print('x')", encoding="utf-8")
+    source.chmod(0o666)
+
     findings = SecurityScanner(tmp_path).check_file_permissions()
+
     assert any(not item.passed and item.id == "SEC_PERM_001" for item in findings)
+
+
+def test_scanner_skips_vcs_and_generated_directories(tmp_path: Path) -> None:
+    _policy_files(tmp_path)
+    for dirname in (".git", "build", "dist", "__pycache__"):
+        directory = tmp_path / dirname
+        directory.mkdir()
+        (directory / "leak.py").write_text(
+            "TOKEN = 'ghp_abcdefghijklmnopqrstuvwxyz123456'\n", encoding="utf-8"
+        )
+
+    report = SecurityScanner(tmp_path).scan()
+
+    assert report["status"] == "SECURE"
+    assert report["failed_items"] == 0


### PR DESCRIPTION
## Phase 3 — Test Infrastructure

This PR establishes a maintainable test/coverage baseline without changing production behavior.

### Changes
- add `requirements-dev.txt` with `pytest-cov`
- configure pytest discovery and strict markers in `pyproject.toml`
- configure branch coverage reporting across project packages
- expand security scanner regression coverage
- add AES-256-GCM encryption regression tests

### Scope
- no production logic changes
- no CI workflow changes (reserved for Phase 4)
- tests are structured so CI can invoke `pytest` and coverage explicitly in the next phase

### Validation note
The connected GitHub environment does not provide a local shell/runner for this repository, so I did not claim an independent local pytest execution. The test suite and configuration were reviewed against the current source APIs; Phase 4 will make execution/enforcement part of GitHub Actions.