### PR TITLE
ci: establish Phase 4 quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: CI Quality Gates
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Python tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -r requirements.txt pytest-cov
+
+      - name: Run tests with coverage
+        run: python -m pytest --cov=yasinai --cov=security_platform --cov=developer_platform --cov=knowledge_platform --cov-report=term-missing --cov-report=xml --cov-fail-under=70
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-python-${{ matrix.python-version }}
+          path: coverage.xml
+          if-no-files-found: ignore
+
+  security:
+    name: Security quality gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install runtime dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -r requirements.txt
+
+      - name: Run repository security check
+        run: python -m yasinai security check
+
+      - name: Check for accidental secret files
+        shell: bash
+        run: |
+          set -euo pipefail
+          forbidden=0
+          while IFS= read -r -d '' file; do
+            case "$file" in
+              ./.git/*|./.venv/*|./venv/*|./node_modules/*) continue ;;
+            esac
+            case "$file" in
+              *.pem|*.key|*.p12|*.pfx|*.token|*.secret) echo "Forbidden secret-like file: $file"; forbidden=1 ;;
+              */.env|./.env|*/.env.*|./.env.*) echo "Forbidden environment file: $file"; forbidden=1 ;;
+            esac
+          done < <(find . -type f -print0)
+          test "$forbidden" -eq 0
+
+  docker:
+    name: Docker smoke test
+    runs-on: ubuntu-latest
+    needs: [test, security]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t yasinai:ci .
+
+      - name: Run Docker smoke test
+        run: docker run --rm yasinai:ci yasin status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: python -m pip install --upgrade pip && python -m pip install -r requirements.txt
 
       - name: Run repository security check
-        run: python -m yasinai security check
+        run: python -c "from yasinai.cli.security_entrypoint import main; main()" security check
 
       - name: Check for accidental secret files
         shell: bash


### PR DESCRIPTION
## Phase 4 — CI/CD Quality Gates

This PR establishes the repository's first real CI quality gates for pull requests and pushes to `main`.

### Included
- Python test matrix for 3.11 and 3.12
- pytest coverage reporting with a 70% minimum gate
- real SecurityScanner invocation
- secret-like file guard
- Docker smoke test gated on test + security jobs
- least-privilege workflow permissions
- workflow concurrency cancellation

### Scope
This phase focuses on CI enforcement. Packaging cleanup/workaround removal remains Phase 5.

No production runtime behavior is intentionally changed.