### PR TITLE
fix: reconcile phase 9 plugin SDK

### DIFF
--- a/developer_platform/__init__.py
+++ b/developer_platform/__init__.py
@@ -11,17 +11,10 @@ from developer_platform.generator import Generator
 from developer_platform.debugger import Debugger
 from developer_platform.profiler import Profiler
 from developer_platform.package_builder import PackageBuilder
+from developer_platform.sdk import PluginError, PluginRegistry, PluginSpec, SDKError, plugin
 
 __all__ = [
-    "Agent",
-    "AgentSDK",
-    "Plugin",
-    "PluginSDK",
-    "AIApplication",
-    "AppSDK",
-    "ExtensionAPI",
-    "Generator",
-    "Debugger",
-    "Profiler",
-    "PackageBuilder",
+    "Agent", "AgentSDK", "Plugin", "PluginSDK", "AIApplication", "AppSDK",
+    "ExtensionAPI", "Generator", "Debugger", "Profiler", "PackageBuilder",
+    "PluginError", "PluginRegistry", "PluginSpec", "SDKError", "plugin",
 ]

--- a/developer_platform/sdk.py
+++ b/developer_platform/sdk.py
@@ -1,0 +1,78 @@
+"""Stable developer-facing SDK primitives for YasinAI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, Optional
+
+
+class SDKError(Exception):
+    """Base exception for developer SDK failures."""
+
+
+class PluginError(SDKError):
+    """Raised when a plugin cannot be registered or invoked."""
+
+
+@dataclass(frozen=True)
+class PluginSpec:
+    """Metadata and callable contract for a YasinAI plugin."""
+
+    name: str
+    handler: Callable[..., Any]
+    version: str = "1.0.0"
+    description: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class PluginRegistry:
+    """Deterministic in-process registry for developer plugins."""
+
+    def __init__(self) -> None:
+        self._plugins: Dict[str, PluginSpec] = {}
+
+    def register(self, plugin: PluginSpec) -> PluginSpec:
+        if not plugin.name or not plugin.name.strip():
+            raise PluginError("plugin name must not be empty")
+        if plugin.name in self._plugins:
+            raise PluginError(f"plugin already registered: {plugin.name}")
+        self._plugins[plugin.name] = plugin
+        return plugin
+
+    def unregister(self, name: str) -> bool:
+        return self._plugins.pop(name, None) is not None
+
+    def get(self, name: str) -> Optional[PluginSpec]:
+        return self._plugins.get(name)
+
+    def list(self) -> Iterable[PluginSpec]:
+        return tuple(self._plugins[name] for name in sorted(self._plugins))
+
+    def invoke(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        plugin = self.get(name)
+        if plugin is None:
+            raise PluginError(f"plugin not found: {name}")
+        return plugin.handler(*args, **kwargs)
+
+
+def plugin(
+    name: str,
+    *,
+    version: str = "1.0.0",
+    description: str = "",
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Declare plugin metadata without coupling the handler to the registry."""
+
+    def decorator(handler: Callable[..., Any]) -> Callable[..., Any]:
+        setattr(
+            handler,
+            "__yasinai_plugin__",
+            PluginSpec(name, handler, version, description, dict(metadata or {})),
+        )
+        return handler
+
+    return decorator
+
+
+__all__ = ["PluginError", "PluginRegistry", "PluginSpec", "SDKError", "plugin"]

--- a/developer_platform/sdk_tests.py
+++ b/developer_platform/sdk_tests.py
@@ -1,0 +1,37 @@
+"""SDK contract tests kept close to the developer platform."""
+
+from .sdk import PluginError, PluginRegistry, PluginSpec, plugin
+
+
+def test_registry_register_list_and_invoke():
+    registry = PluginRegistry()
+    spec = PluginSpec("echo", lambda value: value, description="Echo")
+    registry.register(spec)
+    assert [item.name for item in registry.list()] == ["echo"]
+    assert registry.invoke("echo", "ok") == "ok"
+
+
+def test_registry_rejects_duplicates_and_missing_plugins():
+    registry = PluginRegistry()
+    registry.register(PluginSpec("echo", lambda: None))
+    try:
+        registry.register(PluginSpec("echo", lambda: None))
+        assert False
+    except PluginError:
+        pass
+    try:
+        registry.invoke("missing")
+        assert False
+    except PluginError:
+        pass
+
+
+def test_decorator_exposes_metadata_without_global_registration():
+    @plugin("calculator", version="2.0.0", description="calculator")
+    def calculate(a, b):
+        return a + b
+
+    assert calculate(2, 3) == 5
+    spec = calculate.__yasinai_plugin__
+    assert spec.name == "calculator"
+    assert spec.version == "2.0.0"

--- a/docs/DEVELOPER_SDK.md
+++ b/docs/DEVELOPER_SDK.md
@@ -1,0 +1,19 @@
+# YasinAI Developer SDK
+
+The developer platform exposes a small stable plugin contract without forcing plugins to depend on runtime internals.
+
+## Plugin
+
+```python
+from developer_platform import PluginRegistry, PluginSpec
+
+registry = PluginRegistry()
+registry.register(PluginSpec("echo", lambda value: value))
+result = registry.invoke("echo", "hello")
+```
+
+Plugins have a name, semantic version, description, metadata, and callable handler. Registration is explicit and duplicate names are rejected.
+
+The `@plugin(...)` decorator is available when metadata should travel with a handler before it is registered. It does not mutate global state or implicitly register code.
+
+This API is intentionally synchronous and in-process for Phase 9. Sandboxing, permissions, remote plugins, and lifecycle management belong to later platform layers.


### PR DESCRIPTION
Reconcile the Phase 9 developer SDK with the existing plugin implementation so the stable SDK surface has one canonical contract. Preserve backward compatibility while removing ambiguity between PluginSDK and PluginRegistry.