### PR TITLE
feat: establish observability layer

### DIFF
--- a/observability/__init__.py
+++ b/observability/__init__.py
@@ -1,0 +1,5 @@
+"""Observability primitives."""
+
+from .metrics import Counter, MetricsRegistry, Timer, timed
+
+__all__ = ["Counter", "MetricsRegistry", "Timer", "timed"]

--- a/observability/metrics.py
+++ b/observability/metrics.py
@@ -1,0 +1,83 @@
+"""Dependency-free metrics primitives for YasinAI services."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import wraps
+from threading import Lock
+from time import monotonic
+from typing import Any, Callable, Dict
+
+
+@dataclass
+class Counter:
+    name: str
+    value: int = 0
+    _lock: Lock = field(default_factory=Lock, repr=False)
+
+    def inc(self, amount: int = 1) -> int:
+        if amount < 0:
+            raise ValueError("counter increment must be non-negative")
+        with self._lock:
+            self.value += amount
+            return self.value
+
+
+@dataclass
+class Timer:
+    name: str
+    count: int = 0
+    total_seconds: float = 0.0
+    _lock: Lock = field(default_factory=Lock, repr=False)
+
+    def observe(self, seconds: float) -> float:
+        if seconds < 0:
+            raise ValueError("duration must be non-negative")
+        with self._lock:
+            self.count += 1
+            self.total_seconds += seconds
+            return seconds
+
+    @property
+    def average_seconds(self) -> float:
+        with self._lock:
+            return self.total_seconds / self.count if self.count else 0.0
+
+
+class MetricsRegistry:
+    """Thread-safe in-process registry suitable for service adapters."""
+
+    def __init__(self) -> None:
+        self._counters: Dict[str, Counter] = {}
+        self._timers: Dict[str, Timer] = {}
+        self._lock = Lock()
+
+    def counter(self, name: str) -> Counter:
+        with self._lock:
+            return self._counters.setdefault(name, Counter(name))
+
+    def timer(self, name: str) -> Timer:
+        with self._lock:
+            return self._timers.setdefault(name, Timer(name))
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            counters = {k: v.value for k, v in self._counters.items()}
+            timers = {
+                k: {"count": v.count, "total_seconds": v.total_seconds, "average_seconds": v.average_seconds}
+                for k, v in self._timers.items()
+            }
+        return {"counters": counters, "timers": timers}
+
+
+def timed(registry: MetricsRegistry, name: str) -> Callable:
+    """Record execution duration while preserving the wrapped callable metadata."""
+    def decorator(fn: Callable) -> Callable:
+        @wraps(fn)
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            started = monotonic()
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                registry.timer(name).observe(monotonic() - started)
+        return wrapped
+    return decorator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ include = [
     "developer_platform*",
     "knowledge_platform*",
     "api_service*",
+    "observability*",
 ]
 
 [tool.pytest.ini_options]
@@ -41,7 +42,7 @@ addopts = ["-ra", "--strict-markers"]
 
 [tool.coverage.run]
 branch = true
-source = ["yasinai", "security_platform", "developer_platform", "knowledge_platform", "api_service"]
+source = ["yasinai", "security_platform", "developer_platform", "knowledge_platform", "api_service", "observability"]
 omit = ["tests/*"]
 
 [tool.coverage.report]

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,41 @@
+import pytest
+
+from observability import MetricsRegistry, timed
+
+
+def test_counter_and_timer_snapshot():
+    registry = MetricsRegistry()
+    assert registry.counter("requests").inc() == 1
+    assert registry.counter("requests").inc(2) == 3
+    registry.timer("latency").observe(0.25)
+    snapshot = registry.snapshot()
+    assert snapshot["counters"]["requests"] == 3
+    assert snapshot["timers"]["latency"]["count"] == 1
+    assert snapshot["timers"]["latency"]["total_seconds"] == pytest.approx(0.25)
+
+
+def test_rejects_invalid_observations():
+    registry = MetricsRegistry()
+    with pytest.raises(ValueError):
+        registry.counter("requests").inc(-1)
+    with pytest.raises(ValueError):
+        registry.timer("latency").observe(-0.1)
+
+
+def test_timed_records_success_and_failure():
+    registry = MetricsRegistry()
+
+    @timed(registry, "work")
+    def work(value):
+        return value
+
+    assert work(42) == 42
+    assert registry.timer("work").count == 1
+
+    @timed(registry, "failure")
+    def fail():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        fail()
+    assert registry.timer("failure").count == 1


### PR DESCRIPTION
Phase 11: add dependency-free thread-safe metrics primitives, timing instrumentation, public observability exports, packaging/coverage integration, and regression tests. Keep observability transport-neutral so exporters can be added during deployment without coupling core services to a monitoring vendor.