### PR TITLE
feat: harden production deployment baseline

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,5 +1,10 @@
-# Deployment baseline
+# Deployment
 
-This directory contains the supported local/container deployment baseline for Yasin-AI.
+## Production baseline
 
-The Compose definition is intentionally conservative: persistent data is isolated in a named volume, the container filesystem is read-only, Linux capabilities are dropped, and privilege escalation is disabled.
+1. Copy `.env.example` to `.env` and provide only non-secret runtime configuration there.
+2. Build and start with `docker compose -f compose.production.yml up -d --build`.
+3. Inspect service state with `docker compose -f compose.production.yml ps`.
+4. Inspect logs with `docker compose -f compose.production.yml logs --tail=200`.
+
+The production profile uses a persistent named volume, a read-only root filesystem, dropped Linux capabilities, `no-new-privileges`, bounded CPU/memory/PID resources, and a container healthcheck.

--- a/deploy/compose.production.yml
+++ b/deploy/compose.production.yml
@@ -1,0 +1,30 @@
+services:
+  yasinai:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    init: true
+    env_file:
+      - .env
+    volumes:
+      - yasinai-data:/data
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=64m
+    pids_limit: 256
+    mem_limit: 1g
+    cpus: 2
+    healthcheck:
+      test: ["CMD", "yasin", "status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+volumes:
+  yasinai-data:


### PR DESCRIPTION
Phase 12 deployment hardening. Adds a production Compose profile with persistent storage, read-only filesystem, dropped capabilities, no-new-privileges, resource bounds, init handling, and health checks. Updates deployment documentation with the production workflow.