### PR TITLE
perf: harden reliability and performance contracts

### DIFF
--- a/performance/README.md
+++ b/performance/README.md
@@ -1,14 +1,24 @@
-# Performance baseline
+# Performance and reliability baseline
 
-Phase 14 establishes a lightweight, dependency-free performance contract. Runtime code must avoid unbounded in-memory caches, repeated initialization, and unnecessary work on hot paths. Performance measurements belong outside core business logic.
-
-The existing `observability.metrics` primitives provide counters/timers for future benchmarks without forcing a monitoring vendor into the application.
+Phase 14 establishes a dependency-free performance contract.
 
 ## Reliability rules
 
-- Bound collections and queues when accepting external input.
-- Reuse durable storage connections where appropriate; close them deterministically.
-- Keep startup idempotent.
+- Keep startup and shutdown idempotent.
 - Avoid network calls in constructors.
-- Prefer lazy work for optional subsystems.
-- Add regression tests for every performance optimization that changes behavior.
+- Reuse durable resources and close them deterministically.
+- Bound collections and queues that accept external input.
+- Prefer lazy initialization for optional subsystems.
+- Keep observability instrumentation thread-safe and low overhead.
+- Every optimization that changes behavior must have a regression test.
+
+## Measurement
+
+`observability.metrics` provides lightweight counters and timers for service instrumentation without coupling the application to a monitoring vendor. Benchmarking belongs in CI/release validation rather than in production hot paths.
+
+## Phase 14 acceptance criteria
+
+- Concurrent metric updates do not lose increments.
+- Timing instrumentation records both successful and failed calls.
+- Decorated callables retain their name and docstring.
+- No new runtime dependency is required for the performance layer.

--- a/performance/test_reliability.py
+++ b/performance/test_reliability.py
@@ -1,0 +1,57 @@
+"""Fast regression tests for Phase 14 reliability contracts."""
+from __future__ import annotations
+
+import threading
+
+from observability.metrics import MetricsRegistry, timed
+
+
+def test_metrics_registry_is_thread_safe() -> None:
+    registry = MetricsRegistry()
+    counter = registry.counter("requests")
+
+    def worker() -> None:
+        for _ in range(100):
+            counter.inc()
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert counter.value == 800
+
+
+def test_timed_preserves_callable_metadata_and_records_exception() -> None:
+    registry = MetricsRegistry()
+
+    @timed(registry, "operation")
+    def operation() -> str:
+        """Stable callable contract."""
+        return "ok"
+
+    assert operation.__name__ == "operation"
+    assert operation.__doc__ == "Stable callable contract."
+    assert operation() == "ok"
+
+    snapshot = registry.snapshot()
+    assert snapshot["timers"]["operation"]["count"] == 1
+    assert snapshot["timers"]["operation"]["total_seconds"] >= 0
+
+
+def test_timed_records_failed_operation() -> None:
+    registry = MetricsRegistry()
+
+    @timed(registry, "failed")
+    def failed() -> None:
+        raise RuntimeError("boom")
+
+    try:
+        failed()
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("expected RuntimeError")
+
+    assert registry.snapshot()["timers"]["failed"]["count"] == 1


### PR DESCRIPTION
Phase 14 continuation. Adds concurrency regression coverage for metrics, verifies timing instrumentation on successful and failed calls, preserves callable metadata, and documents measurable performance/reliability acceptance criteria. No runtime dependency is introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a performance and reliability contract covering safe startup and shutdown, resource cleanup, bounded inputs, optional initialization, and instrumentation requirements.
  * Documented measurement guidance and acceptance criteria for concurrent updates and operation timing.

* **Tests**
  * Added regression coverage for thread-safe metrics, callable metadata preservation, and timing records for successful and failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->