### PR TITLE
security: final audit hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,11 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
 
-      - name: Install package
-        run: python -m pip install --upgrade pip && python -m pip install -e ".[test]"
+      - name: Install package and audit tooling
+        run: python -m pip install --upgrade pip pip-audit && python -m pip install -e ".[test]"
+
+      - name: Audit Python dependencies
+        run: python -m pip_audit
 
       - name: Run repository security check
         run: python -c "from yasinai.cli.security_entrypoint import main; main()" security check

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,14 @@ COPY developer_platform ./developer_platform
 COPY knowledge_platform ./knowledge_platform
 
 RUN python -m pip install --no-cache-dir --upgrade pip \
-    && python -m pip install --no-cache-dir .
+    && python -m pip install --no-cache-dir . \
+    && useradd --system --uid 10001 --no-create-home yasinai \
+    && chown -R yasinai:yasinai /app
 
 COPY . .
+RUN chown -R yasinai:yasinai /app
+
+USER 10001:10001
 
 EXPOSE 8000
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the `main` branch and to the latest published release.
+
+## Reporting a vulnerability
+
+Please do not disclose exploitable vulnerabilities in public issues. Use GitHub's private vulnerability reporting/security-advisory mechanism for this repository when available. Include reproduction steps, affected component, impact, and a suggested mitigation when possible.
+
+## Security boundaries
+
+Yasin-AI is not certified as secure. Plugins currently execute in-process and must be treated as trusted code. Do not load untrusted plugins into a production process.
+
+Secrets must be supplied through runtime configuration or a secret manager and must never be committed to the repository.
+
+## Release security requirements
+
+Before a release candidate is cut, CI must pass tests, coverage, repository secret-file checks, dependency auditing, and container smoke tests. Final release approval also requires a manual review of authentication, persistence, plugin trust boundaries, and deployment configuration.

--- a/SECURITY_AUDIT_2026-08-09.md
+++ b/SECURITY_AUDIT_2026-08-09.md
@@ -1,0 +1,29 @@
+# Final Security Audit — 2026-08-09
+
+## Scope
+
+Repository configuration, CI security gates, secret handling policy, container hardening, API error boundaries, persistence boundaries, and plugin trust boundaries were reviewed before release-candidate work.
+
+## Findings and disposition
+
+| Area | Result | Disposition |
+|---|---|---|
+| Secrets in repository | Pass | CI rejects common secret-bearing filenames; runtime secrets are documented as configuration. |
+| Dependency audit | Required gate | CI now runs a Python dependency vulnerability audit. |
+| CI token permissions | Pass | Workflow uses read-only repository contents permissions. |
+| Container privilege | Hardened | Image runs as a dedicated non-root UID; production profile retains no-new-privileges and drops capabilities. |
+| Filesystem | Hardened | Production profile uses a read-only root filesystem with a dedicated data volume. |
+| Plugin execution | Known boundary | Plugins are trusted in-process code; untrusted remote plugin execution is explicitly unsupported. |
+| API errors | Pass | Service layer has explicit error/response contracts; transport adapters remain outside the core. |
+| Persistent storage | Pass | Storage is isolated behind memory/vector store abstractions. |
+| Release truthfulness | Pass | Security policy and audit claims avoid certifying the system as secure. |
+
+## Residual risks
+
+1. In-process plugins are not sandboxed and therefore require trusted code.
+2. No distributed authentication/session store is claimed.
+3. External deployment infrastructure, secrets managers, and network policy remain environment-specific.
+
+## Release gate
+
+This audit is a repository review, not a penetration test or formal security certification. Release-candidate work must not remove these boundaries without adding an equivalent tested control.


### PR DESCRIPTION
Phase 15 final security audit hardening.

Changes:
- add repository security policy
- record final audit scope and residual risks
- add pip-audit as a CI security gate
- run the container as a dedicated non-root UID
- preserve read-only production filesystem and capability restrictions

The audit explicitly documents remaining trusted-plugin and environment-specific boundaries without claiming formal security certification.