### PR TITLE
release: publish v1.0.0 production baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
-## [1.0.0] - 2026-07-26
+## [1.0.0] - 2026-08-09
 
 ### Added
-- Core Runtime fully implemented (config, system info, service registry, dynamic bootstrap loading, lifecycle orchestration) (Issue #1).
-- Updated documentation repository-wide (README.md, MASTER_PLAN.md, ARCHITECTURE.md, PROJECT_STATUS.md, CHANGELOG.md) to ensure perfect structural consistency with implemented files and CLI options (including global `--json` argument and sub-command specific arguments).
-- Developer Platform implemented with Agent SDK, Plugin SDK, Application SDK, CLI tool templates, generator, debugger, and profiler (Issue #2).
-- Security Platform implemented with Identity, Authentication, Authorization, Encryption, Key Management, Secret Storage, and Threat Detection (Issue #3).
-- Knowledge Platform fully implemented with Short Term Memory, Long Term Memory, Knowledge Graph, Semantic Search, Context Engine, and Reasoning (Issue #4).
-- CLI System implemented with status, agent create, memory search, security check, and package build commands (Issue #5).
-- Deployment System implemented with Installer, Docker Manager, Health Check, and shared Package Builder (Issue #6).
-- Comprehensive unit tests for all systems including Core Runtime, Developer Platform, Security Platform, Knowledge Platform, CLI System, and Deployment System.
-- Created `Dockerfile` and `docker-compose.yml` configurations at the repository root.
-- Created `requirements.txt` at the repository root.
-- Added GitHub release preparation and repository-wide release audit checks (Issue #7).
+- Hardened modular runtime and deterministic lifecycle management.
+- Persistent SQLite-backed long-term memory and semantic retrieval.
+- Developer plugin SDK and deterministic plugin registry.
+- Transport-neutral API/service layer.
+- Dependency-free observability metrics.
+- Hardened container deployment baseline.
+- Security policy, dependency audit gate, and final security audit record.
+- Release-candidate verification and production release documentation.
+
+### Security
+- Dependency auditing is enforced in CI.
+- Secret-like files are rejected by CI checks.
+- Production container uses a non-root runtime, read-only root filesystem, dropped capabilities, and `no-new-privileges`.
+
+### Known limitations
+- Plugins are trusted and execute in-process.
+- Local SQLite persistence is not a distributed high-availability datastore.
+- Production infrastructure security remains the responsibility of the deployment environment.

--- a/PRODUCTION_RELEASE.md
+++ b/PRODUCTION_RELEASE.md
@@ -1,0 +1,32 @@
+# Yasin-AI v1.0.0 Production Release
+
+Release target: `v1.0.0`
+
+## Gate status
+
+- Security audit completed.
+- Release-candidate checklist completed.
+- CI test, coverage, dependency-audit, repository-security, and Docker smoke-test gates are defined.
+- Packaging metadata reports version `1.0.0`.
+- Production deployment hardening is documented.
+- Known limitations are documented and intentionally accepted for this release.
+
+## Deployment verification
+
+Before exposing a deployment to users, run:
+
+```bash
+python -m pytest -q
+pip-audit
+python -m build
+```
+
+Then build and exercise the production container/compose profile in the target environment and verify its healthcheck.
+
+## Rollback
+
+Keep the previous known-good image/package available. If a production deployment fails health checks or introduces a regression, redeploy the previous artifact and investigate from the release commit and CI artifacts.
+
+## Scope
+
+This release establishes the first production baseline of the modular YasinAI platform. Distributed HA storage, untrusted plugin sandboxing, and vendor-specific observability exporters remain future infrastructure work.


### PR DESCRIPTION
Phase 17 production release preparation. Finalizes the v1.0.0 changelog and adds the production release checklist, deployment verification, rollback guidance, scope, and explicitly documented limitations. The release is based on the Phase 16 release-candidate baseline.