### PR TITLE
Yasin-AI: Phase 2.5 — AI Capability Contracts v1

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -245,7 +245,7 @@ End of Project Status
 | 2.2 Architecture Reconciliation | COMPLETED — merged |
 | 2.3 Version & Release Consistency | COMPLETED — PR #60 merged 2026-08-14 |
 | 2.4 AI Capability Catalog | COMPLETED — AI_CAPABILITY_CATALOG.md 2026-08-14 |
-| 2.5 AI Capability Contracts v1 | NEXT |
-| 2.6 Provider Architecture Audit | PENDING |
+| 2.5 AI Capability Contracts v1 | COMPLETED — yasinai/contracts/ v1, 34 tests, 2026-08-14 |
+| 2.6 Provider Architecture Audit | NEXT |
 | 2.7 Memory & Knowledge Architecture Reconciliation | PENDING |
 | 2.8 Foundation Tests, CI & Integration Readiness | PENDING |

--- a/docs/CAPABILITY_CONTRACTS_V1.md
+++ b/docs/CAPABILITY_CONTRACTS_V1.md
@@ -1,0 +1,136 @@
+# Yasin-AI Capability Contracts v1
+
+**Status:** Stable  
+**Contract version:** v1  
+**Platform version:** 1.1.0  
+**Date:** 2026-08-14
+
+---
+
+## Purpose
+
+These contracts define the **public integration boundary** between Yasin-AI
+and all consumer projects (Yasin-Agent, YasinHub, YasinCLI, YasinRelay,
+YasinFeed, YasinPress).
+
+Consumers import from `yasinai.contracts`, never from internal modules such
+as `knowledge_platform`, `developer_platform`, or `security_platform`.
+
+---
+
+## Package
+
+```python
+from yasinai.contracts import (
+    # base
+    CapabilityError,
+    CapabilityUnavailableError,
+    ContractViolationError,
+    ObservabilityContext,
+    CapabilityMetadata,
+    # memory
+    MemoryRequest, MemoryResponse, MemoryEntry, MemoryType,
+    # knowledge
+    KnowledgeQuery, KnowledgeResult, KnowledgeEntry, KnowledgeQueryType,
+    # embedding
+    EmbeddingRequest, EmbeddingResponse, EmbeddingVector,
+    # plugin
+    PluginContract, PluginInvokeRequest, PluginInvokeResponse,
+)
+```
+
+---
+
+## Contracts
+
+### Memory (`yasinai.contracts.memory`)
+
+Covers short-term (in-process) and long-term (SQLite-backed) memory operations.
+
+| Type | Role |
+|---|---|
+| `MemoryRequest` | Input: operation, type, key, content, limit, metadata |
+| `MemoryResponse` | Output: success, entry/entries, deleted, error, meta |
+| `MemoryEntry` | A single stored record (content, timestamp, key, metadata) |
+| `MemoryType` | Enum: `SHORT_TERM` / `LONG_TERM` |
+
+Operations: `store` · `retrieve` · `delete` · `list` · `clear`
+
+### Knowledge (`yasinai.contracts.knowledge`)
+
+Covers knowledge graph queries, triple-store lookups, and transitive reasoning.
+
+| Type | Role |
+|---|---|
+| `KnowledgeQuery` | Input: query_type, text, subject, predicate, relation, top_k |
+| `KnowledgeResult` | Output: success, entries, error, meta |
+| `KnowledgeEntry` | A single result (content, score, source, metadata) |
+| `KnowledgeQueryType` | Enum: `SEMANTIC` / `GRAPH` / `TRIPLE` / `REASONING` |
+
+### Embedding (`yasinai.contracts.embedding`)
+
+Covers vector embedding for semantic search and RAG pipelines.
+Currently backed by stdlib TF-IDF engine; contract is provider-neutral.
+
+| Type | Role |
+|---|---|
+| `EmbeddingRequest` | Input: texts, model hint, metadata |
+| `EmbeddingResponse` | Output: success, vectors, error, meta |
+| `EmbeddingVector` | A single embedding (text, vector, model, metadata) |
+
+### Plugin (`yasinai.contracts.plugin`)
+
+Covers cross-repo plugin invocation.
+
+| Type | Role |
+|---|---|
+| `PluginInvokeRequest` | Input: name, args, kwargs, context |
+| `PluginInvokeResponse` | Output: success, result, error, meta |
+| `PluginContract` | Metadata for a registered plugin |
+
+---
+
+## Base Types (shared by all contracts)
+
+| Type | Purpose |
+|---|---|
+| `CapabilityError` | Base error; has `.code` and `.as_dict()` |
+| `CapabilityUnavailableError` | Capability not configured / not implemented |
+| `ContractViolationError` | Caller passed invalid input |
+| `ObservabilityContext` | `trace_id`, `span_id`, `caller`, `metadata` — flows through every request |
+| `CapabilityMetadata` | `capability`, `contract_version`, `platform_version`, `provider` — returned in every response |
+
+---
+
+## Versioning policy
+
+- Contract version (`v1`) is **separate** from platform version (`1.1.0`).
+- Backward-compatible additions (new optional fields) do not bump the contract version.
+- Breaking changes require a new contract version (`v2`) and an ADR.
+- `contract_version` is embedded in every `CapabilityMetadata` response so consumers can detect mismatches at runtime.
+
+---
+
+## What is NOT in v1
+
+The following capability contracts are **PLANNED** and will be added in Phase 3
+once the provider gateway exists:
+
+- `GenerationRequest / GenerationResponse` (requires LLM provider)
+- `ChatRequest / ChatResponse` (requires LLM provider)
+- `SummarizationRequest / SummarizationResponse`
+- `ClassificationRequest / ClassificationResponse`
+- `RAGRequest / RAGResponse` (requires unified pipeline)
+
+Do not implement these until the provider abstraction (Phase 2.6 / Phase 3) is stable.
+
+---
+
+## Tests
+
+`tests/test_contracts.py` — 34 tests covering all contract types,
+validation rules, error codes, and observability context propagation.
+
+---
+
+*Related: `AI_CAPABILITY_CATALOG.md`, `VERSIONING_POLICY.md`, ADR-001, ADR-0007*

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,0 +1,262 @@
+"""
+Tests for Yasin-AI Public Capability Contracts v1
+Phase 2.5
+"""
+import pytest
+
+from yasinai.contracts import CONTRACT_VERSION
+from yasinai.contracts.base import (
+    CapabilityError,
+    CapabilityMetadata,
+    CapabilityUnavailableError,
+    ContractViolationError,
+    ObservabilityContext,
+)
+from yasinai.contracts.memory import MemoryEntry, MemoryRequest, MemoryResponse, MemoryType
+from yasinai.contracts.knowledge import (
+    KnowledgeEntry,
+    KnowledgeQuery,
+    KnowledgeQueryType,
+    KnowledgeResult,
+)
+from yasinai.contracts.embedding import EmbeddingRequest, EmbeddingResponse, EmbeddingVector
+from yasinai.contracts.plugin import (
+    PluginContract,
+    PluginInvokeRequest,
+    PluginInvokeResponse,
+)
+
+
+# ---------------------------------------------------------------------------
+# Contract version
+# ---------------------------------------------------------------------------
+
+def test_contract_version():
+    assert CONTRACT_VERSION == "v1"
+
+
+# ---------------------------------------------------------------------------
+# Base types
+# ---------------------------------------------------------------------------
+
+def test_capability_error_has_code():
+    err = CapabilityError("something failed", code="TEST_CODE")
+    assert err.code == "TEST_CODE"
+    assert err.as_dict() == {"error": "something failed", "code": "TEST_CODE"}
+
+
+def test_capability_unavailable_error():
+    err = CapabilityUnavailableError("generation")
+    assert err.code == "CAPABILITY_UNAVAILABLE"
+    assert "generation" in str(err)
+
+
+def test_contract_violation_error():
+    err = ContractViolationError("bad input")
+    assert err.code == "CONTRACT_VIOLATION"
+
+
+def test_observability_context_defaults():
+    ctx = ObservabilityContext()
+    assert ctx.trace_id is None
+    assert ctx.caller is None
+    assert ctx.metadata == {}
+
+
+def test_capability_metadata_defaults():
+    meta = CapabilityMetadata(capability="memory")
+    assert meta.contract_version == "v1"
+    assert meta.platform_version == "1.1.0"
+    assert meta.provider is None
+
+
+# ---------------------------------------------------------------------------
+# Memory contract
+# ---------------------------------------------------------------------------
+
+def test_memory_request_short_term_store():
+    req = MemoryRequest(operation="store", content="hello", memory_type=MemoryType.SHORT_TERM)
+    assert req.operation == "store"
+    assert req.content == "hello"
+
+
+def test_memory_request_long_term_store_requires_key():
+    with pytest.raises(ContractViolationError, match="key"):
+        MemoryRequest(operation="store", content="x", memory_type=MemoryType.LONG_TERM)
+
+
+def test_memory_request_long_term_store_with_key():
+    req = MemoryRequest(
+        operation="store",
+        content="data",
+        key="my-key",
+        memory_type=MemoryType.LONG_TERM,
+    )
+    assert req.key == "my-key"
+
+
+def test_memory_request_invalid_operation():
+    with pytest.raises(ContractViolationError, match="operation"):
+        MemoryRequest(operation="flush")
+
+
+def test_memory_request_store_without_content():
+    with pytest.raises(ContractViolationError, match="content"):
+        MemoryRequest(operation="store")
+
+
+def test_memory_response_success():
+    entry = MemoryEntry(content="hello", timestamp=1.0, key="k1")
+    resp = MemoryResponse(success=True, entry=entry)
+    assert resp.success
+    assert resp.entry.content == "hello"
+    assert resp.meta.capability == "memory"
+
+
+def test_memory_response_failure():
+    resp = MemoryResponse(success=False, error="not found")
+    assert not resp.success
+    assert resp.error == "not found"
+
+
+def test_memory_type_values():
+    assert MemoryType.SHORT_TERM == "short_term"
+    assert MemoryType.LONG_TERM == "long_term"
+
+
+# ---------------------------------------------------------------------------
+# Knowledge contract
+# ---------------------------------------------------------------------------
+
+def test_knowledge_query_semantic_requires_text():
+    with pytest.raises(ContractViolationError, match="text"):
+        KnowledgeQuery(query_type=KnowledgeQueryType.SEMANTIC)
+
+
+def test_knowledge_query_semantic_valid():
+    q = KnowledgeQuery(query_type=KnowledgeQueryType.SEMANTIC, text="what is Yasin?", top_k=3)
+    assert q.text == "what is Yasin?"
+    assert q.top_k == 3
+
+
+def test_knowledge_query_graph_requires_subject():
+    with pytest.raises(ContractViolationError, match="subject"):
+        KnowledgeQuery(query_type=KnowledgeQueryType.GRAPH)
+
+
+def test_knowledge_query_graph_valid():
+    q = KnowledgeQuery(query_type=KnowledgeQueryType.GRAPH, subject="Yasin-AI")
+    assert q.subject == "Yasin-AI"
+
+
+def test_knowledge_query_reasoning_requires_subject_and_relation():
+    with pytest.raises(ContractViolationError):
+        KnowledgeQuery(query_type=KnowledgeQueryType.REASONING, subject="A")
+
+
+def test_knowledge_query_reasoning_valid():
+    q = KnowledgeQuery(
+        query_type=KnowledgeQueryType.REASONING,
+        subject="A",
+        relation="is_part_of",
+    )
+    assert q.relation == "is_part_of"
+
+
+def test_knowledge_result_success():
+    entry = KnowledgeEntry(content="Yasin-AI is the canonical AI platform", score=0.9)
+    result = KnowledgeResult(success=True, entries=[entry])
+    assert result.success
+    assert len(result.entries) == 1
+    assert result.entries[0].score == 0.9
+    assert result.meta.capability == "knowledge"
+
+
+def test_knowledge_result_failure():
+    result = KnowledgeResult(success=False, error="index not found")
+    assert not result.success
+
+
+# ---------------------------------------------------------------------------
+# Embedding contract
+# ---------------------------------------------------------------------------
+
+def test_embedding_request_requires_texts():
+    with pytest.raises(ContractViolationError, match="texts"):
+        EmbeddingRequest(texts=[])
+
+
+def test_embedding_request_requires_string_texts():
+    with pytest.raises(ContractViolationError, match="strings"):
+        EmbeddingRequest(texts=["valid", 123])  # type: ignore
+
+
+def test_embedding_request_valid():
+    req = EmbeddingRequest(texts=["hello", "world"])
+    assert len(req.texts) == 2
+
+
+def test_embedding_response_success():
+    vectors = [
+        EmbeddingVector(text="hello", vector=[0.1, 0.2, 0.3]),
+        EmbeddingVector(text="world", vector=[0.4, 0.5, 0.6]),
+    ]
+    resp = EmbeddingResponse(success=True, vectors=vectors)
+    assert resp.success
+    assert len(resp.vectors) == 2
+    assert resp.meta.capability == "embedding"
+
+
+def test_embedding_response_failure():
+    resp = EmbeddingResponse(success=False, error="provider unavailable")
+    assert not resp.success
+
+
+# ---------------------------------------------------------------------------
+# Plugin contract
+# ---------------------------------------------------------------------------
+
+def test_plugin_invoke_request_requires_name():
+    with pytest.raises(ContractViolationError, match="name"):
+        PluginInvokeRequest(name="")
+
+
+def test_plugin_invoke_request_valid():
+    req = PluginInvokeRequest(name="my-plugin", args=[1, 2], kwargs={"key": "val"})
+    assert req.name == "my-plugin"
+    assert req.args == [1, 2]
+
+
+def test_plugin_invoke_response_success():
+    resp = PluginInvokeResponse(success=True, result={"output": 42})
+    assert resp.success
+    assert resp.result["output"] == 42
+    assert resp.meta.capability == "plugin"
+
+
+def test_plugin_invoke_response_failure():
+    resp = PluginInvokeResponse(success=False, error="plugin not found")
+    assert not resp.success
+
+
+def test_plugin_contract_metadata():
+    pc = PluginContract(name="summarizer", version="1.0.0", description="Summarizes text")
+    assert pc.name == "summarizer"
+    assert pc.version == "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Observability context flows through requests
+# ---------------------------------------------------------------------------
+
+def test_observability_context_in_memory_request():
+    ctx = ObservabilityContext(trace_id="trace-123", caller="yasin-agent")
+    req = MemoryRequest(operation="list", context=ctx)
+    assert req.context.trace_id == "trace-123"
+    assert req.context.caller == "yasin-agent"
+
+
+def test_observability_context_in_knowledge_query():
+    ctx = ObservabilityContext(trace_id="trace-456")
+    q = KnowledgeQuery(query_type=KnowledgeQueryType.SEMANTIC, text="test", context=ctx)
+    assert q.context.trace_id == "trace-456"

--- a/yasinai/contracts/__init__.py
+++ b/yasinai/contracts/__init__.py
@@ -1,0 +1,68 @@
+"""
+Yasin-AI Public Capability Contracts v1
+
+Stable, versioned contracts that define the boundary between
+Yasin-AI and its consumers (Yasin-Agent, YasinHub, YasinCLI,
+YasinRelay, YasinFeed, YasinPress).
+
+Import from here, never from internal implementation modules.
+"""
+
+from yasinai.contracts.base import (
+    CapabilityError,
+    CapabilityUnavailableError,
+    ContractViolationError,
+    ObservabilityContext,
+    CapabilityMetadata,
+)
+from yasinai.contracts.memory import (
+    MemoryRequest,
+    MemoryResponse,
+    MemoryEntry,
+    MemoryType,
+)
+from yasinai.contracts.knowledge import (
+    KnowledgeQuery,
+    KnowledgeResult,
+    KnowledgeEntry,
+    KnowledgeQueryType,
+)
+from yasinai.contracts.embedding import (
+    EmbeddingRequest,
+    EmbeddingResponse,
+    EmbeddingVector,
+)
+from yasinai.contracts.plugin import (
+    PluginContract,
+    PluginInvokeRequest,
+    PluginInvokeResponse,
+)
+
+__all__ = [
+    # base
+    "CapabilityError",
+    "CapabilityUnavailableError",
+    "ContractViolationError",
+    "ObservabilityContext",
+    "CapabilityMetadata",
+    # memory
+    "MemoryRequest",
+    "MemoryResponse",
+    "MemoryEntry",
+    "MemoryType",
+    # knowledge
+    "KnowledgeQuery",
+    "KnowledgeResult",
+    "KnowledgeEntry",
+    "KnowledgeQueryType",
+    # embedding
+    "EmbeddingRequest",
+    "EmbeddingResponse",
+    "EmbeddingVector",
+    # plugin
+    "PluginContract",
+    "PluginInvokeRequest",
+    "PluginInvokeResponse",
+]
+
+CONTRACT_VERSION = "v1"

--- a/yasinai/contracts/base.py
+++ b/yasinai/contracts/base.py
@@ -1,0 +1,56 @@
+"""
+Base types shared across all Yasin-AI Capability Contracts v1.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+class CapabilityError(Exception):
+    """Base error for all Yasin-AI capability failures."""
+
+    def __init__(self, message: str, code: str = "CAPABILITY_ERROR") -> None:
+        super().__init__(message)
+        self.code = code
+
+    def as_dict(self) -> Dict[str, str]:
+        return {"error": str(self), "code": self.code}
+
+
+class CapabilityUnavailableError(CapabilityError):
+    """Raised when a capability is not yet implemented or not configured."""
+
+    def __init__(self, capability: str) -> None:
+        super().__init__(
+            f"Capability '{capability}' is not available in this deployment.",
+            code="CAPABILITY_UNAVAILABLE",
+        )
+        self.capability = capability
+
+
+class ContractViolationError(CapabilityError):
+    """Raised when a caller violates the contract (bad input, missing fields)."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, code="CONTRACT_VIOLATION")
+
+
+@dataclass(frozen=True)
+class ObservabilityContext:
+    """Opaque tracing/logging context passed through capability calls."""
+
+    trace_id: Optional[str] = None
+    span_id: Optional[str] = None
+    caller: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CapabilityMetadata:
+    """Describes the capability and its version at the response boundary."""
+
+    capability: str
+    contract_version: str = "v1"
+    platform_version: str = "1.1.0"
+    provider: Optional[str] = None

--- a/yasinai/contracts/embedding.py
+++ b/yasinai/contracts/embedding.py
@@ -1,0 +1,76 @@
+"""
+Embedding Capability Contract v1
+
+Stable interface for producing and comparing vector embeddings.
+Currently backed by the stdlib TF-IDF engine in knowledge_platform.
+Designed to accept external providers (OpenAI, etc.) in Phase 3
+without changing this contract.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from yasinai.contracts.base import (
+    CapabilityMetadata,
+    ContractViolationError,
+    ObservabilityContext,
+)
+
+
+@dataclass(frozen=True)
+class EmbeddingRequest:
+    """
+    Input contract for an embedding operation.
+
+    Attributes:
+        texts:      One or more texts to embed
+        model:      Optional provider model hint (ignored by stdlib engine)
+        metadata:   Caller-supplied context
+        context:    Observability tracing context
+    """
+
+    texts: List[str]
+    model: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    context: Optional[ObservabilityContext] = None
+
+    def __post_init__(self) -> None:
+        if not self.texts:
+            raise ContractViolationError(
+                "EmbeddingRequest: 'texts' must contain at least one entry"
+            )
+        if any(not isinstance(t, str) for t in self.texts):
+            raise ContractViolationError(
+                "EmbeddingRequest: all entries in 'texts' must be strings"
+            )
+
+
+@dataclass(frozen=True)
+class EmbeddingVector:
+    """A single embedding result."""
+
+    text: str
+    vector: List[float]
+    model: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EmbeddingResponse:
+    """
+    Output contract for an embedding operation.
+
+    Attributes:
+        success:   True if all embeddings were produced
+        vectors:   One EmbeddingVector per input text, same order
+        error:     Error message if success is False
+        meta:      Capability metadata
+    """
+
+    success: bool
+    vectors: List[EmbeddingVector] = field(default_factory=list)
+    error: Optional[str] = None
+    meta: CapabilityMetadata = field(
+        default_factory=lambda: CapabilityMetadata(capability="embedding")
+    )

--- a/yasinai/contracts/knowledge.py
+++ b/yasinai/contracts/knowledge.py
@@ -1,0 +1,96 @@
+"""
+Knowledge Capability Contract v1
+
+Stable interface for knowledge graph queries and semantic retrieval.
+Backed by knowledge_platform — consumers must not import that directly.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from yasinai.contracts.base import (
+    CapabilityMetadata,
+    ContractViolationError,
+    ObservabilityContext,
+)
+
+
+class KnowledgeQueryType(str, Enum):
+    SEMANTIC = "semantic"       # TF-IDF / vector similarity search
+    GRAPH = "graph"             # Knowledge graph traversal
+    TRIPLE = "triple"           # Subject / predicate / object lookup
+    REASONING = "reasoning"     # Transitive deduction over graph
+
+
+@dataclass(frozen=True)
+class KnowledgeQuery:
+    """
+    Input contract for a knowledge retrieval operation.
+
+    Attributes:
+        query_type:  Type of retrieval to perform
+        text:        Natural-language or keyword query (SEMANTIC)
+        subject:     Entity name for GRAPH / TRIPLE queries
+        predicate:   Relation name for TRIPLE queries
+        relation:    Relation name for REASONING (transitive)
+        top_k:       Max results for SEMANTIC queries (default 5)
+        metadata:    Caller-supplied context
+        context:     Observability tracing context
+    """
+
+    query_type: KnowledgeQueryType
+    text: Optional[str] = None
+    subject: Optional[str] = None
+    predicate: Optional[str] = None
+    relation: Optional[str] = None
+    top_k: int = 5
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    context: Optional[ObservabilityContext] = None
+
+    def __post_init__(self) -> None:
+        if self.query_type == KnowledgeQueryType.SEMANTIC and not self.text:
+            raise ContractViolationError(
+                "KnowledgeQuery: SEMANTIC query requires 'text'"
+            )
+        if self.query_type in {KnowledgeQueryType.GRAPH, KnowledgeQueryType.TRIPLE}:
+            if not self.subject:
+                raise ContractViolationError(
+                    f"KnowledgeQuery: {self.query_type} query requires 'subject'"
+                )
+        if self.query_type == KnowledgeQueryType.REASONING:
+            if not self.subject or not self.relation:
+                raise ContractViolationError(
+                    "KnowledgeQuery: REASONING query requires 'subject' and 'relation'"
+                )
+
+
+@dataclass(frozen=True)
+class KnowledgeEntry:
+    """A single result from a knowledge query."""
+
+    content: Any
+    score: float = 1.0
+    source: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class KnowledgeResult:
+    """
+    Output contract for a knowledge query.
+
+    Attributes:
+        success:  True if the query completed without error
+        entries:  Ordered list of results (highest relevance first)
+        error:    Error message if success is False
+        meta:     Capability metadata
+    """
+
+    success: bool
+    entries: List[KnowledgeEntry] = field(default_factory=list)
+    error: Optional[str] = None
+    meta: CapabilityMetadata = field(
+        default_factory=lambda: CapabilityMetadata(capability="knowledge")
+    )

--- a/yasinai/contracts/memory.py
+++ b/yasinai/contracts/memory.py
@@ -1,0 +1,94 @@
+"""
+Memory Capability Contract v1
+
+Stable interface for short-term and long-term memory operations.
+Backed by knowledge_platform.memory — consumers must not import that directly.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from yasinai.contracts.base import (
+    CapabilityMetadata,
+    ContractViolationError,
+    ObservabilityContext,
+)
+
+
+class MemoryType(str, Enum):
+    SHORT_TERM = "short_term"
+    LONG_TERM = "long_term"
+
+
+@dataclass(frozen=True)
+class MemoryRequest:
+    """
+    Input contract for a memory operation.
+
+    Attributes:
+        operation:  "store" | "retrieve" | "delete" | "list" | "clear"
+        memory_type: SHORT_TERM or LONG_TERM
+        key:        Required for long-term store/retrieve/delete
+        content:    Required for store operations
+        limit:      Optional; for short-term retrieve (top-N most recent)
+        metadata:   Caller-supplied metadata attached to stored entries
+        context:    Observability tracing context
+    """
+
+    operation: str
+    memory_type: MemoryType = MemoryType.SHORT_TERM
+    key: Optional[str] = None
+    content: Optional[Any] = None
+    limit: Optional[int] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    context: Optional[ObservabilityContext] = None
+
+    def __post_init__(self) -> None:
+        valid_ops = {"store", "retrieve", "delete", "list", "clear"}
+        if self.operation not in valid_ops:
+            raise ContractViolationError(
+                f"MemoryRequest.operation must be one of {valid_ops}, got '{self.operation}'"
+            )
+        if self.operation == "store" and self.content is None:
+            raise ContractViolationError("MemoryRequest: 'store' operation requires 'content'")
+        if self.memory_type == MemoryType.LONG_TERM and self.operation in {"store", "retrieve", "delete"}:
+            if not self.key:
+                raise ContractViolationError(
+                    f"MemoryRequest: long-term '{self.operation}' requires 'key'"
+                )
+
+
+@dataclass(frozen=True)
+class MemoryEntry:
+    """A single memory record returned in a MemoryResponse."""
+
+    content: Any
+    timestamp: float
+    key: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MemoryResponse:
+    """
+    Output contract for a memory operation.
+
+    Attributes:
+        success:  True if the operation completed without error
+        entries:  Populated for retrieve/list operations
+        entry:    Populated for single-key retrieve
+        deleted:  True if a delete operation removed the entry
+        error:    Error message if success is False
+        meta:     Capability metadata (version, provider, etc.)
+    """
+
+    success: bool
+    entries: List[MemoryEntry] = field(default_factory=list)
+    entry: Optional[MemoryEntry] = None
+    deleted: bool = False
+    error: Optional[str] = None
+    meta: CapabilityMetadata = field(
+        default_factory=lambda: CapabilityMetadata(capability="memory")
+    )

--- a/yasinai/contracts/plugin.py
+++ b/yasinai/contracts/plugin.py
@@ -1,0 +1,70 @@
+"""
+Plugin Capability Contract v1
+
+Stable cross-repo interface for plugin invocation.
+Backed by developer_platform.sdk — consumers must not import that directly.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from yasinai.contracts.base import (
+    CapabilityMetadata,
+    ContractViolationError,
+    ObservabilityContext,
+)
+
+
+@dataclass(frozen=True)
+class PluginContract:
+    """Metadata describing a registered plugin at the public boundary."""
+
+    name: str
+    version: str
+    description: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PluginInvokeRequest:
+    """
+    Input contract for invoking a plugin.
+
+    Attributes:
+        name:     Registered plugin name
+        args:     Positional arguments for the plugin handler
+        kwargs:   Keyword arguments for the plugin handler
+        context:  Observability tracing context
+    """
+
+    name: str
+    args: List[Any] = field(default_factory=list)
+    kwargs: Dict[str, Any] = field(default_factory=dict)
+    context: Optional[ObservabilityContext] = None
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.name.strip():
+            raise ContractViolationError(
+                "PluginInvokeRequest: 'name' must not be empty"
+            )
+
+
+@dataclass(frozen=True)
+class PluginInvokeResponse:
+    """
+    Output contract for a plugin invocation.
+
+    Attributes:
+        success:  True if the plugin completed without error
+        result:   Return value from the plugin handler
+        error:    Error message if success is False
+        meta:     Capability metadata
+    """
+
+    success: bool
+    result: Any = None
+    error: Optional[str] = None
+    meta: CapabilityMetadata = field(
+        default_factory=lambda: CapabilityMetadata(capability="plugin")
+    )


### PR DESCRIPTION
## Phase 2.5 — AI Capability Contracts v1

Public stable boundary between Yasin-AI and all consumers.

### New files
- `yasinai/contracts/__init__.py` — public import surface
- `yasinai/contracts/base.py` — CapabilityError, ObservabilityContext, CapabilityMetadata
- `yasinai/contracts/memory.py` — MemoryRequest/Response/Entry/Type
- `yasinai/contracts/knowledge.py` — KnowledgeQuery/Result/Entry/QueryType
- `yasinai/contracts/embedding.py` — EmbeddingRequest/Response/Vector
- `yasinai/contracts/plugin.py` — PluginInvokeRequest/Response, PluginContract
- `tests/test_contracts.py` — 34 tests
- `docs/CAPABILITY_CONTRACTS_V1.md` — versioning policy and usage guide

### Design decisions
- Frozen dataclasses with `__post_init__` validation
- `ObservabilityContext` flows through every request
- `CapabilityMetadata` (contract_version=v1, platform_version=1.1.0) in every response
- `GenerationRequest/ChatRequest` deliberately absent — blocked on Phase 3 provider gateway
- Contract version (`v1`) is separate from platform version (`1.1.0`)

### Tests
149 passed, 0 failed (34 new contract tests + 115 existing)