### PR TITLE
Yasin-AI: Phase 2.6 — Provider Architecture Boundary

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -246,6 +246,6 @@ End of Project Status
 | 2.3 Version & Release Consistency | COMPLETED — PR #60 merged 2026-08-14 |
 | 2.4 AI Capability Catalog | COMPLETED — AI_CAPABILITY_CATALOG.md 2026-08-14 |
 | 2.5 AI Capability Contracts v1 | COMPLETED — yasinai/contracts/ v1, 34 tests, 2026-08-14 |
-| 2.6 Provider Architecture Audit | NEXT |
-| 2.7 Memory & Knowledge Architecture Reconciliation | PENDING |
+| 2.6 Provider Architecture Audit | COMPLETED — yasinai/providers/ boundary, 23 tests, 2026-08-14 |
+| 2.7 Memory & Knowledge Architecture Reconciliation | NEXT |
 | 2.8 Foundation Tests, CI & Integration Readiness | PENDING |

--- a/docs/PROVIDER_ARCHITECTURE.md
+++ b/docs/PROVIDER_ARCHITECTURE.md
@@ -1,0 +1,151 @@
+# Yasin-AI — Provider Architecture
+
+**Phase:** 2.6  
+**Status:** Boundary defined. Concrete providers: Phase 3.  
+**Date:** 2026-08-14
+
+---
+
+## Boundary Rule
+
+Provider SDK libraries (openai, anthropic, etc.) must **never** be imported
+outside `yasinai/providers/`. The rest of Yasin-AI depends only on:
+
+```
+yasinai.providers.base    — ProviderBase, GenerationRequest/Response, ProviderCapability
+yasinai.providers.registry — ProviderRegistry
+yasinai.providers.router   — ProviderRouter
+```
+
+Public contracts (`yasinai.contracts`) are separate and provider-neutral.
+Consumer projects import from `yasinai.contracts`, not from `yasinai.providers`.
+
+---
+
+## Architecture
+
+```
+Consumer (Yasin-Agent, YasinRelay, ...)
+        │
+        ▼
+yasinai.contracts (GenerationRequest — public, provider-neutral)
+        │
+        ▼
+Yasin-AI service layer (Phase 3)
+        │
+        ▼
+ProviderRouter.select(capability, model_hint)
+        │
+        ▼
+ProviderRegistry — available providers
+        │
+        ├── OpenAIProvider   (Phase 3)
+        ├── AnthropicProvider (Phase 3)
+        ├── LocalProvider    (Phase 3)
+        └── ...
+```
+
+---
+
+## Components
+
+### ProviderBase (`yasinai/providers/base.py`)
+Abstract interface every provider adapter implements.
+
+- `info → ProviderInfo` — name, version, capabilities, model_ids
+- `is_available() → bool` — runtime health check (no I/O in this call)
+- `generate(GenerationRequest) → GenerationResponse`
+- `ProviderError` — only exception type that may escape an adapter
+
+### ProviderRegistry (`yasinai/providers/registry.py`)
+Thread-safe in-process registry. One per Runtime instance.
+
+- `register(provider, overwrite=False)`
+- `get(name) → Optional[ProviderBase]`
+- `for_capability(cap) → List[ProviderBase]`
+- `available_for_capability(cap) → List[ProviderBase]`
+
+### ProviderRouter (`yasinai/providers/router.py`)
+Selects the best available provider for a capability + optional model hint.
+
+**Phase 2.6 routing policy (simple):**
+1. Filter to providers supporting the capability and `is_available()`.
+2. If `model` hint given, prefer provider whose `model_ids` contains it.
+3. Otherwise first available wins.
+4. If none: `ProviderUnavailableError`.
+
+**Phase 3 extensions (not yet):** priority weights, cost routing, fallback chains, config-driven.
+
+---
+
+## Credential Policy
+
+- Provider credentials (API keys) are **never** stored in source or config files.
+- Adapters read credentials from environment variables only.
+- Credential names will be documented per-adapter in Phase 3.
+- `is_available()` must not block or make network calls — it checks env vars only.
+
+---
+
+## Adding a Provider (Phase 3 guide)
+
+```python
+# yasinai/providers/openai_provider.py
+
+import os
+from yasinai.providers.base import (
+    ProviderBase, ProviderCapability, ProviderError,
+    ProviderInfo, GenerationRequest, GenerationResponse,
+)
+
+class OpenAIProvider(ProviderBase):
+
+    @property
+    def info(self) -> ProviderInfo:
+        return ProviderInfo(
+            name="openai",
+            version="1.0.0",
+            capabilities=[
+                ProviderCapability.GENERATION,
+                ProviderCapability.CHAT,
+                ProviderCapability.EMBEDDING,
+            ],
+            model_ids=["gpt-4o", "gpt-4o-mini", "text-embedding-3-small"],
+        )
+
+    def is_available(self) -> bool:
+        return bool(os.environ.get("OPENAI_API_KEY"))
+
+    def _generate(self, request: GenerationRequest) -> GenerationResponse:
+        try:
+            import openai  # imported here, not at module level
+            ...
+        except Exception as exc:
+            raise ProviderError("openai", str(exc), retryable=True) from exc
+```
+
+Register at runtime startup:
+```python
+from yasinai.providers import ProviderRegistry
+from yasinai.providers.openai_provider import OpenAIProvider
+
+registry = ProviderRegistry()
+registry.register(OpenAIProvider())
+```
+
+---
+
+## Phase 2.6 Audit Findings
+
+| Item | Finding |
+|---|---|
+| Provider SDK imports | None exist in codebase — clean boundary |
+| Provider dependencies in pyproject.toml | None — correct for Phase 2 |
+| Provider leakage into contracts | None — contracts are provider-neutral |
+| Model routing | Skeleton implemented, Phase 3 for production policy |
+| Credential handling | No hardcoded secrets found |
+| Retry/fallback | Defined as ProviderRouter responsibility — Phase 3 |
+
+---
+
+*Related: `AI_CAPABILITY_CATALOG.md`, `docs/CAPABILITY_CONTRACTS_V1.md`, ADR-0007*

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,264 @@
+"""
+Tests for Yasin-AI Provider Abstraction Layer
+Phase 2.6
+"""
+import pytest
+
+from yasinai.providers.base import (
+    GenerationRequest,
+    GenerationResponse,
+    ProviderBase,
+    ProviderCapability,
+    ProviderError,
+    ProviderInfo,
+)
+from yasinai.providers.registry import ProviderRegistry, ProviderRegistryError
+from yasinai.providers.router import ProviderRouter, ProviderUnavailableError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — stub provider implementations
+# ---------------------------------------------------------------------------
+
+class StubGenerationProvider(ProviderBase):
+    """Minimal stub that supports GENERATION and is always available."""
+
+    def __init__(self, name: str = "stub-gen", models: list = None, available: bool = True):
+        self._name = name
+        self._models = models or ["stub-model-v1"]
+        self._available = available
+
+    @property
+    def info(self) -> ProviderInfo:
+        return ProviderInfo(
+            name=self._name,
+            version="0.1.0",
+            capabilities=[ProviderCapability.GENERATION],
+            model_ids=self._models,
+        )
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def _generate(self, request: GenerationRequest) -> GenerationResponse:
+        return GenerationResponse(
+            text=f"echo: {request.prompt}",
+            model=request.model or self._models[0],
+            provider=self._name,
+        )
+
+
+class StubEmbeddingProvider(ProviderBase):
+    """Stub that supports only EMBEDDING."""
+
+    @property
+    def info(self) -> ProviderInfo:
+        return ProviderInfo(
+            name="stub-embed",
+            capabilities=[ProviderCapability.EMBEDDING],
+            model_ids=["embed-v1"],
+        )
+
+    def is_available(self) -> bool:
+        return True
+
+
+class UnavailableProvider(ProviderBase):
+    """Stub that is always unavailable."""
+
+    @property
+    def info(self) -> ProviderInfo:
+        return ProviderInfo(
+            name="unavailable",
+            capabilities=[ProviderCapability.GENERATION],
+            model_ids=[],
+        )
+
+    def is_available(self) -> bool:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# GenerationRequest validation
+# ---------------------------------------------------------------------------
+
+def test_generation_request_valid():
+    req = GenerationRequest(prompt="hello", model="stub-model-v1")
+    assert req.prompt == "hello"
+    assert req.max_tokens == 1024
+
+
+def test_generation_request_empty_prompt():
+    with pytest.raises(ValueError, match="prompt"):
+        GenerationRequest(prompt="")
+
+
+def test_generation_request_invalid_temperature():
+    with pytest.raises(ValueError, match="temperature"):
+        GenerationRequest(prompt="x", temperature=3.0)
+
+
+def test_generation_request_invalid_max_tokens():
+    with pytest.raises(ValueError, match="max_tokens"):
+        GenerationRequest(prompt="x", max_tokens=0)
+
+
+# ---------------------------------------------------------------------------
+# ProviderBase interface
+# ---------------------------------------------------------------------------
+
+def test_provider_info():
+    p = StubGenerationProvider()
+    assert p.info.name == "stub-gen"
+    assert ProviderCapability.GENERATION in p.info.capabilities
+
+
+def test_provider_generate_works():
+    p = StubGenerationProvider()
+    req = GenerationRequest(prompt="test prompt")
+    resp = p.generate(req)
+    assert resp.text == "echo: test prompt"
+    assert resp.provider == "stub-gen"
+
+
+def test_provider_generate_wrong_capability():
+    p = StubEmbeddingProvider()
+    req = GenerationRequest(prompt="test")
+    with pytest.raises(NotImplementedError):
+        p.generate(req)
+
+
+def test_provider_error():
+    err = ProviderError("my-provider", "connection refused", retryable=True)
+    assert err.provider == "my-provider"
+    assert err.retryable is True
+    assert "my-provider" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# ProviderRegistry
+# ---------------------------------------------------------------------------
+
+def test_registry_register_and_get():
+    reg = ProviderRegistry()
+    p = StubGenerationProvider()
+    reg.register(p)
+    assert reg.get("stub-gen") is p
+
+
+def test_registry_duplicate_raises():
+    reg = ProviderRegistry()
+    p = StubGenerationProvider()
+    reg.register(p)
+    with pytest.raises(ProviderRegistryError):
+        reg.register(StubGenerationProvider())
+
+
+def test_registry_overwrite():
+    reg = ProviderRegistry()
+    p1 = StubGenerationProvider(name="gen")
+    p2 = StubGenerationProvider(name="gen")
+    reg.register(p1)
+    reg.register(p2, overwrite=True)
+    assert reg.get("gen") is p2
+
+
+def test_registry_unregister():
+    reg = ProviderRegistry()
+    reg.register(StubGenerationProvider())
+    assert reg.unregister("stub-gen") is True
+    assert reg.get("stub-gen") is None
+    assert reg.unregister("stub-gen") is False
+
+
+def test_registry_list():
+    reg = ProviderRegistry()
+    reg.register(StubGenerationProvider())
+    reg.register(StubEmbeddingProvider())
+    names = [i.name for i in reg.list()]
+    assert "stub-gen" in names
+    assert "stub-embed" in names
+
+
+def test_registry_for_capability():
+    reg = ProviderRegistry()
+    reg.register(StubGenerationProvider())
+    reg.register(StubEmbeddingProvider())
+    gen_providers = reg.for_capability(ProviderCapability.GENERATION)
+    assert len(gen_providers) == 1
+    assert gen_providers[0].info.name == "stub-gen"
+
+
+def test_registry_available_for_capability_excludes_unavailable():
+    reg = ProviderRegistry()
+    reg.register(UnavailableProvider())
+    result = reg.available_for_capability(ProviderCapability.GENERATION)
+    assert result == []
+
+
+def test_registry_len():
+    reg = ProviderRegistry()
+    assert len(reg) == 0
+    reg.register(StubGenerationProvider())
+    assert len(reg) == 1
+
+
+# ---------------------------------------------------------------------------
+# ProviderRouter
+# ---------------------------------------------------------------------------
+
+def test_router_selects_available_provider():
+    reg = ProviderRegistry()
+    reg.register(StubGenerationProvider())
+    router = ProviderRouter(reg)
+    provider = router.select(ProviderCapability.GENERATION)
+    assert provider.info.name == "stub-gen"
+
+
+def test_router_selects_by_model_hint():
+    reg = ProviderRegistry()
+    reg.register(StubGenerationProvider(name="provider-a", models=["model-a"]))
+    reg.register(StubGenerationProvider(name="provider-b", models=["model-b"]))
+    router = ProviderRouter(reg)
+    provider = router.select(ProviderCapability.GENERATION, model="model-b")
+    assert provider.info.name == "provider-b"
+
+
+def test_router_falls_back_when_no_model_match():
+    reg = ProviderRegistry()
+    reg.register(StubGenerationProvider(name="only-provider", models=["model-x"]))
+    router = ProviderRouter(reg)
+    # unknown-model has no exact match — falls back to first available
+    provider = router.select(ProviderCapability.GENERATION, model="unknown-model")
+    assert provider.info.name == "only-provider"
+
+
+def test_router_raises_when_no_provider():
+    reg = ProviderRegistry()
+    router = ProviderRouter(reg)
+    with pytest.raises(ProviderUnavailableError) as exc_info:
+        router.select(ProviderCapability.GENERATION)
+    assert exc_info.value.capability == ProviderCapability.GENERATION
+
+
+def test_router_raises_when_all_unavailable():
+    reg = ProviderRegistry()
+    reg.register(UnavailableProvider())
+    router = ProviderRouter(reg)
+    with pytest.raises(ProviderUnavailableError):
+        router.select(ProviderCapability.GENERATION)
+
+
+def test_router_respects_capability_boundary():
+    reg = ProviderRegistry()
+    reg.register(StubEmbeddingProvider())
+    router = ProviderRouter(reg)
+    with pytest.raises(ProviderUnavailableError) as exc_info:
+        router.select(ProviderCapability.GENERATION)
+    assert exc_info.value.capability == ProviderCapability.GENERATION
+
+
+def test_provider_unavailable_error_message():
+    err = ProviderUnavailableError(ProviderCapability.GENERATION, model="gpt-4o")
+    assert "generation" in str(err)
+    assert "gpt-4o" in str(err)

--- a/yasinai/providers/__init__.py
+++ b/yasinai/providers/__init__.py
@@ -1,0 +1,37 @@
+"""
+Yasin-AI Provider Abstraction Layer
+
+This package defines the provider boundary for Yasin-AI.
+It contains:
+  - The public ProviderBase interface (all providers implement this)
+  - The ProviderRegistry (single registry, per-Runtime instance)
+  - The ProviderRouter (select provider by capability/model hint)
+  - Provider-specific adapters (Phase 3 — not yet implemented)
+
+STATUS: Phase 2.6 — boundary defined.
+        Phase 3 will implement concrete providers (OpenAI, Anthropic, local).
+
+Usage (Phase 3+):
+    from yasinai.providers import ProviderRegistry, ProviderRouter
+    from yasinai.providers.base import ProviderBase, GenerationRequest, GenerationResponse
+"""
+
+from yasinai.providers.base import (
+    ProviderBase,
+    ProviderCapability,
+    ProviderInfo,
+    GenerationRequest,
+    GenerationResponse,
+)
+from yasinai.providers.registry import ProviderRegistry
+from yasinai.providers.router import ProviderRouter
+
+__all__ = [
+    "ProviderBase",
+    "ProviderCapability",
+    "ProviderInfo",
+    "GenerationRequest",
+    "GenerationResponse",
+    "ProviderRegistry",
+    "ProviderRouter",
+]

--- a/yasinai/providers/base.py
+++ b/yasinai/providers/base.py
@@ -1,0 +1,120 @@
+"""
+Yasin-AI Provider Base Interface
+
+All provider adapters (OpenAI, Anthropic, local models, etc.) must
+implement ProviderBase. This is the only interface the rest of Yasin-AI
+depends on — never import provider SDK libraries outside this package.
+
+Phase 2.6: interface defined.
+Phase 3: concrete implementations added here as submodules.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class ProviderCapability(str, Enum):
+    """Capabilities a provider may or may not support."""
+    GENERATION = "generation"
+    CHAT = "chat"
+    EMBEDDING = "embedding"
+    VISION = "vision"
+    SPEECH_TO_TEXT = "speech_to_text"
+    TEXT_TO_SPEECH = "text_to_speech"
+    STRUCTURED_OUTPUT = "structured_output"
+    FUNCTION_CALLING = "function_calling"
+
+
+@dataclass(frozen=True)
+class ProviderInfo:
+    """Static metadata about a registered provider."""
+    name: str
+    version: str = "unknown"
+    capabilities: List[ProviderCapability] = field(default_factory=list)
+    model_ids: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class GenerationRequest:
+    """
+    Input for text generation.
+    Mirrors yasinai.contracts — this internal version may carry
+    provider-specific hints that are not part of the public contract.
+    """
+    prompt: str
+    model: Optional[str] = None
+    max_tokens: int = 1024
+    temperature: float = 0.7
+    system_prompt: Optional[str] = None
+    stop_sequences: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.prompt:
+            raise ValueError("GenerationRequest: 'prompt' must not be empty")
+        if not 0.0 <= self.temperature <= 2.0:
+            raise ValueError("GenerationRequest: 'temperature' must be between 0.0 and 2.0")
+        if self.max_tokens < 1:
+            raise ValueError("GenerationRequest: 'max_tokens' must be >= 1")
+
+
+@dataclass(frozen=True)
+class GenerationResponse:
+    """Output from a text generation call."""
+    text: str
+    model: str
+    provider: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    finish_reason: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class ProviderBase(ABC):
+    """
+    Abstract base for all Yasin-AI provider adapters.
+
+    Implementations live in yasinai/providers/<name>.py (Phase 3).
+    They must:
+      - Not leak provider SDK types outside this package
+      - Handle their own retry/rate-limit at the adapter level
+      - Raise ProviderError (not SDK exceptions) on failure
+    """
+
+    @property
+    @abstractmethod
+    def info(self) -> ProviderInfo:
+        """Return static metadata about this provider."""
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Return True if the provider is reachable and configured."""
+
+    def generate(self, request: GenerationRequest) -> GenerationResponse:
+        """
+        Generate text. Raises NotImplementedError if GENERATION
+        is not in self.info.capabilities.
+        """
+        if ProviderCapability.GENERATION not in self.info.capabilities:
+            raise NotImplementedError(
+                f"Provider '{self.info.name}' does not support GENERATION"
+            )
+        return self._generate(request)
+
+    def _generate(self, request: GenerationRequest) -> GenerationResponse:
+        raise NotImplementedError
+
+
+class ProviderError(Exception):
+    """
+    Raised by provider adapters when a call fails.
+    Always use this — never let provider SDK exceptions escape the adapter.
+    """
+    def __init__(self, provider: str, message: str, retryable: bool = False) -> None:
+        super().__init__(f"[{provider}] {message}")
+        self.provider = provider
+        self.retryable = retryable

--- a/yasinai/providers/registry.py
+++ b/yasinai/providers/registry.py
@@ -1,0 +1,72 @@
+"""
+Provider Registry — single registry per Runtime instance.
+
+Providers register themselves by name; the registry does NOT import
+any provider SDK. Each provider adapter self-registers on import.
+
+Phase 2.6: registry skeleton defined.
+Phase 3: concrete providers register here.
+"""
+from __future__ import annotations
+
+import logging
+from threading import Lock
+from typing import Dict, Iterable, List, Optional
+
+from yasinai.providers.base import ProviderBase, ProviderCapability, ProviderInfo
+
+logger = logging.getLogger(__name__)
+
+
+class ProviderRegistryError(Exception):
+    pass
+
+
+class ProviderRegistry:
+    """Thread-safe registry of provider adapters."""
+
+    def __init__(self) -> None:
+        self._providers: Dict[str, ProviderBase] = {}
+        self._lock = Lock()
+
+    def register(self, provider: ProviderBase, *, overwrite: bool = False) -> None:
+        name = provider.info.name
+        with self._lock:
+            if name in self._providers and not overwrite:
+                raise ProviderRegistryError(
+                    f"Provider '{name}' is already registered. "
+                    "Use overwrite=True to replace it."
+                )
+            self._providers[name] = provider
+            logger.info("Provider registered: %s (capabilities: %s)", name,
+                        [c.value for c in provider.info.capabilities])
+
+    def unregister(self, name: str) -> bool:
+        with self._lock:
+            existed = name in self._providers
+            self._providers.pop(name, None)
+            return existed
+
+    def get(self, name: str) -> Optional[ProviderBase]:
+        with self._lock:
+            return self._providers.get(name)
+
+    def list(self) -> List[ProviderInfo]:
+        with self._lock:
+            return [p.info for p in self._providers.values()]
+
+    def for_capability(self, capability: ProviderCapability) -> List[ProviderBase]:
+        """Return all providers that support a given capability."""
+        with self._lock:
+            return [
+                p for p in self._providers.values()
+                if capability in p.info.capabilities
+            ]
+
+    def available_for_capability(self, capability: ProviderCapability) -> List[ProviderBase]:
+        """Return providers that support the capability AND report is_available()."""
+        return [p for p in self.for_capability(capability) if p.is_available()]
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._providers)

--- a/yasinai/providers/router.py
+++ b/yasinai/providers/router.py
@@ -1,0 +1,76 @@
+"""
+Provider Router — selects the best available provider for a capability.
+
+Routing policy (Phase 2.6):
+  1. If model hint is given, prefer the provider whose model_ids contain it.
+  2. Otherwise, return the first available provider for the capability.
+  3. If none available, raise ProviderUnavailableError.
+
+Phase 3 will extend this with priority weights, cost routing, and
+fallback chains defined in configuration.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from yasinai.providers.base import ProviderBase, ProviderCapability, ProviderError
+from yasinai.providers.registry import ProviderRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class ProviderUnavailableError(ProviderError):
+    """Raised when no provider is available for the requested capability."""
+    def __init__(self, capability: ProviderCapability, model: Optional[str] = None) -> None:
+        msg = f"No available provider for capability '{capability.value}'"
+        if model:
+            msg += f" with model hint '{model}'"
+        super().__init__(provider="router", message=msg, retryable=False)
+        self.capability = capability
+        self.model = model
+
+
+class ProviderRouter:
+    """
+    Selects a provider for a given capability + optional model hint.
+
+    Usage:
+        router = ProviderRouter(registry)
+        provider = router.select(ProviderCapability.GENERATION, model="gpt-4o")
+        response = provider.generate(request)
+    """
+
+    def __init__(self, registry: ProviderRegistry) -> None:
+        self._registry = registry
+
+    def select(
+        self,
+        capability: ProviderCapability,
+        model: Optional[str] = None,
+    ) -> ProviderBase:
+        candidates = self._registry.available_for_capability(capability)
+
+        if not candidates:
+            raise ProviderUnavailableError(capability, model)
+
+        if model:
+            # Prefer a provider that explicitly lists this model_id
+            for provider in candidates:
+                if model in provider.info.model_ids:
+                    logger.debug(
+                        "Router: selected '%s' for capability=%s model=%s",
+                        provider.info.name, capability.value, model,
+                    )
+                    return provider
+            # Fall through: use first available if no exact model match
+            logger.debug(
+                "Router: no exact model match for '%s'; using first available provider '%s'",
+                model, candidates[0].info.name,
+            )
+
+        logger.debug(
+            "Router: selected '%s' for capability=%s",
+            candidates[0].info.name, capability.value,
+        )
+        return candidates[0]


### PR DESCRIPTION
## Phase 2.6 — Provider Architecture Audit & Boundary

### Scope
Boundary definition only — no concrete provider implementations (Phase 3).

### New files
- `yasinai/providers/base.py` — ProviderBase ABC, ProviderCapability, GenerationRequest/Response, ProviderError
- `yasinai/providers/registry.py` — thread-safe ProviderRegistry
- `yasinai/providers/router.py` — ProviderRouter (capability + model-hint routing)
- `tests/test_providers.py` — 23 tests
- `docs/PROVIDER_ARCHITECTURE.md` — boundary rules, component docs, Phase 3 guide

### Key decisions
- Provider SDK libs (openai, anthropic, etc.) must only be imported inside `yasinai/providers/`
- `is_available()` checks env vars only — no network calls
- `ProviderError` is the only exception that may escape an adapter
- `yasinai.contracts` remains provider-neutral
- Retry/fallback/priority routing: Phase 3

### Audit findings
- No provider SDK imports anywhere in codebase ✅
- No hardcoded credentials ✅
- No provider leakage into contracts ✅

### Tests
172 passed, 0 failed (23 new + 149 existing)