### PR TITLE
feat(phase-2.7): memory & knowledge architecture reconciliation

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -247,5 +247,5 @@ End of Project Status
 | 2.4 AI Capability Catalog | COMPLETED — AI_CAPABILITY_CATALOG.md 2026-08-14 |
 | 2.5 AI Capability Contracts v1 | COMPLETED — yasinai/contracts/ v1, 34 tests, 2026-08-14 |
 | 2.6 Provider Architecture Audit | COMPLETED — yasinai/providers/ boundary, 23 tests, 2026-08-14 |
-| 2.7 Memory & Knowledge Architecture Reconciliation | NEXT |
-| 2.8 Foundation Tests, CI & Integration Readiness | PENDING |
+| 2.7 Memory & Knowledge Architecture Reconciliation | COMPLETED — docs/MEMORY_KNOWLEDGE_ARCHITECTURE.md, yasinai/services/KnowledgeService, 14 tests |
+| 2.8 Foundation Tests, CI & Integration Readiness | NEXT |

--- a/docs/MEMORY_KNOWLEDGE_ARCHITECTURE.md
+++ b/docs/MEMORY_KNOWLEDGE_ARCHITECTURE.md
@@ -1,0 +1,149 @@
+# Yasin-AI — Memory & Knowledge Architecture
+
+**Phase:** 2.7  
+**Status:** Boundary defined. Service facade: KnowledgeService.  
+**Date:** 2026-08-14  
+**Platform version:** 1.1.0
+
+---
+
+## Purpose
+
+This document reconciles the **Memory**, **Knowledge**, **Retrieval**, and **RAG** boundaries
+inside Yasin-AI. It defines which concerns live where, how consumers access them,
+and the rules that keep internal modules (`knowledge_platform/`) hidden behind
+stable public contracts and a thin service facade.
+
+---
+
+## Core Boundary Rule
+
+| Layer | Location | Who may import |
+|---|---|---|
+| **Public contracts** | `yasinai.contracts` | Consumers (Yasin-Agent, YasinHub, …) and service layer |
+| **Service facade** | `yasinai.services` | Consumers (preferred) and internal orchestration |
+| **Internal implementation** | `knowledge_platform/` | **Only** `yasinai.services` and tests |
+
+Consumers **must not** import `knowledge_platform` directly.
+They import contracts and/or the `KnowledgeService` facade.
+
+---
+
+## Conceptual Separation
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Consumer (Yasin-Agent, YasinHub, YasinCLI, …)                  │
+│       import from yasinai.contracts  OR  yasinai.services       │
+└────────────────────────────┬────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  yasinai.services.KnowledgeService   (facade — Phase 2.7)       │
+│  • translates contracts ↔ internal types                        │
+│  • owns lifecycle of MemoryManager / KnowledgeGraph / Retriever │
+└────────────────────────────┬────────────────────────────────────┘
+                             │
+          ┌──────────────────┼──────────────────┐
+          ▼                  ▼                  ▼
+   ┌─────────────┐   ┌──────────────┐   ┌─────────────────┐
+   │   Memory    │   │  Knowledge   │   │   Retrieval     │
+   │  (STM/LTM)  │   │   Graph      │   │  (Semantic /    │
+   │             │   │  + Reasoning │   │   TF-IDF RAG)   │
+   └─────────────┘   └──────────────┘   └─────────────────┘
+          │                  │                  │
+          └──────────────────┼──────────────────┘
+                             ▼
+                  knowledge_platform/  (INTERNAL)
+```
+
+### 1. Memory
+
+- **Short-term (STM):** process-local, capacity-bounded, FIFO eviction.
+- **Long-term (LTM):** durable (SQLite by default via `YASINAI_MEMORY_PATH`).
+- Contract: `MemoryRequest` / `MemoryResponse` / `MemoryEntry` / `MemoryType`.
+- Operations: `store`, `retrieve`, `delete`, `list`, `clear`.
+
+Memory is **not** a vector store. It stores opaque content + metadata keyed by
+conversation or application keys. Semantic search over memory content is a
+Retrieval concern, not a Memory concern.
+
+### 2. Knowledge
+
+- Entity–relation–triple graph (`KnowledgeGraph`, `TripleStore`, `QueryEngine`).
+- Reasoning / transitive deduction (`KnowledgeReasoner`, `RuleEngine`).
+- Contract: `KnowledgeQuery` / `KnowledgeResult` / `KnowledgeEntry` /
+  `KnowledgeQueryType` (`SEMANTIC` | `GRAPH` | `TRIPLE` | `REASONING`).
+
+Knowledge answers structured questions about entities and relations.
+It does not own conversational history (that is Memory).
+
+### 3. Retrieval
+
+- TF-IDF / in-process vector similarity (`SemanticSearch`, `Retriever`,
+  `EmbeddingEngine`, `VectorStore` / `SQLiteVectorStore`).
+- Used for document ranking and lightweight RAG context assembly.
+- Exposed to consumers via `KnowledgeQueryType.SEMANTIC` on the same
+  knowledge contract surface (no separate retrieval contract in v1).
+
+### 4. RAG (Retrieval-Augmented Generation)
+
+- **Orchestration** lives in the future `yasinai.services.rag_service`
+  (Phase 3). Phase 2.7 only defines the retrieval half and the memory /
+  knowledge boundaries that RAG will compose.
+- RAG will call:
+  1. Retrieval (semantic) → context chunks
+  2. optionally Memory (conversation history)
+  3. Generation via ProviderRouter (Phase 3)
+
+No generation SDKs are imported in the knowledge/memory path.
+
+---
+
+## Service Facade: KnowledgeService
+
+```python
+from yasinai.services import KnowledgeService
+from yasinai.contracts import KnowledgeQuery, KnowledgeQueryType, MemoryRequest
+
+svc = KnowledgeService()          # owns internal MemoryManager + graph + retriever
+result = svc.query(KnowledgeQuery(query_type=KnowledgeQueryType.SEMANTIC, text="…"))
+mem   = svc.memory(MemoryRequest(operation="store", content="…"))
+```
+
+Responsibilities:
+
+- Construct and hold the internal `MemoryManager`, `KnowledgeGraph`, and
+  `Retriever` (or accept injected instances for tests).
+- Map contract types ↔ internal dicts / objects.
+- Never leak `knowledge_platform` types to callers.
+- Return contract-compliant responses even on internal errors
+  (`success=False`, `error=…`).
+
+---
+
+## Explicit Non-Goals (Phase 2.7)
+
+- No concrete LLM provider implementations (Phase 3).
+- No full RAG orchestrator (Phase 3).
+- No namespace move of `knowledge_platform/` under `yasinai/` (deferred).
+- No change to the public contract shapes defined in Phase 2.5.
+
+---
+
+## Related Documents
+
+| Document | Role |
+|---|---|
+| `docs/CAPABILITY_CONTRACTS_V1.md` | Public contract shapes |
+| `docs/PROVIDER_ARCHITECTURE.md` | Provider boundary (Phase 2.6) |
+| `docs/ARCHITECTURE.md` | Overall architecture |
+| `AI_CAPABILITY_CATALOG.md` | Capability inventory |
+
+---
+
+## Change Log
+
+| Date | Change |
+|---|---|
+| 2026-08-14 | Initial reconciliation (Phase 2.7). KnowledgeService facade added. |

--- a/tests/test_knowledge_service.py
+++ b/tests/test_knowledge_service.py
@@ -1,0 +1,260 @@
+"""
+Tests for KnowledgeService facade (Phase 2.7).
+
+Covers memory operations and knowledge/retrieval/reasoning queries
+through the public service layer without importing knowledge_platform
+from the test consumer surface (tests may import internals for setup).
+"""
+from __future__ import annotations
+
+import pytest
+
+from yasinai.contracts.knowledge import (
+    KnowledgeQuery,
+    KnowledgeQueryType,
+    KnowledgeResult,
+)
+from yasinai.contracts.memory import (
+    MemoryRequest,
+    MemoryResponse,
+    MemoryType,
+)
+from yasinai.services import KnowledgeService
+from yasinai.services.knowledge_service import KnowledgeService as KS
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def svc(tmp_path, monkeypatch):
+    """Isolated service with temp long-term memory and vector paths."""
+    monkeypatch.setenv("YASINAI_MEMORY_PATH", str(tmp_path / "mem.db"))
+    monkeypatch.setenv("YASINAI_VECTOR_PATH", str(tmp_path / "vectors.db"))
+    from knowledge_platform.memory import MemoryManager
+    from knowledge_platform.graph import KnowledgeGraph
+    from knowledge_platform.semantic_search import Retriever
+
+    return KnowledgeService(
+        memory_manager=MemoryManager(),
+        knowledge_graph=KnowledgeGraph(),
+        retriever=Retriever(path=str(tmp_path / "vectors.db")),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Memory — short-term
+# ---------------------------------------------------------------------------
+
+def test_memory_store_short_term(svc):
+    resp = svc.memory(
+        MemoryRequest(operation="store", content="hello stm", memory_type=MemoryType.SHORT_TERM)
+    )
+    assert resp.success is True
+    assert resp.entry is not None
+    assert resp.entry.content == "hello stm"
+    assert resp.meta.capability == "memory"
+
+
+def test_memory_retrieve_short_term(svc):
+    svc.memory(MemoryRequest(operation="store", content="a", memory_type=MemoryType.SHORT_TERM))
+    svc.memory(MemoryRequest(operation="store", content="b", memory_type=MemoryType.SHORT_TERM))
+    resp = svc.memory(
+        MemoryRequest(operation="retrieve", memory_type=MemoryType.SHORT_TERM, limit=10)
+    )
+    assert resp.success is True
+    assert len(resp.entries) == 2
+    contents = {e.content for e in resp.entries}
+    assert contents == {"a", "b"}
+
+
+def test_memory_clear_short_term(svc):
+    svc.memory(MemoryRequest(operation="store", content="x", memory_type=MemoryType.SHORT_TERM))
+    resp = svc.memory(MemoryRequest(operation="clear", memory_type=MemoryType.SHORT_TERM))
+    assert resp.success is True
+    after = svc.memory(
+        MemoryRequest(operation="retrieve", memory_type=MemoryType.SHORT_TERM)
+    )
+    assert after.entries == []
+
+
+# ---------------------------------------------------------------------------
+# Memory — long-term
+# ---------------------------------------------------------------------------
+
+def test_memory_store_and_retrieve_long_term(svc):
+    store = svc.memory(
+        MemoryRequest(
+            operation="store",
+            key="policy",
+            content="encrypt keys",
+            memory_type=MemoryType.LONG_TERM,
+            metadata={"type": "rule"},
+        )
+    )
+    assert store.success is True
+    assert store.entry is not None
+    assert store.entry.key == "policy"
+
+    get = svc.memory(
+        MemoryRequest(operation="retrieve", key="policy", memory_type=MemoryType.LONG_TERM)
+    )
+    assert get.success is True
+    assert get.entry is not None
+    assert get.entry.content == "encrypt keys"
+    assert get.entry.metadata.get("type") == "rule"
+
+
+def test_memory_delete_long_term(svc):
+    svc.memory(
+        MemoryRequest(
+            operation="store",
+            key="tmp",
+            content="to-delete",
+            memory_type=MemoryType.LONG_TERM,
+        )
+    )
+    deleted = svc.memory(
+        MemoryRequest(operation="delete", key="tmp", memory_type=MemoryType.LONG_TERM)
+    )
+    assert deleted.success is True
+    assert deleted.deleted is True
+
+    missing = svc.memory(
+        MemoryRequest(operation="retrieve", key="tmp", memory_type=MemoryType.LONG_TERM)
+    )
+    assert missing.entry is None
+
+
+def test_memory_list_long_term(svc):
+    svc.memory(
+        MemoryRequest(
+            operation="store", key="k1", content="c1", memory_type=MemoryType.LONG_TERM
+        )
+    )
+    svc.memory(
+        MemoryRequest(
+            operation="store", key="k2", content="c2", memory_type=MemoryType.LONG_TERM
+        )
+    )
+    listed = svc.memory(MemoryRequest(operation="list", memory_type=MemoryType.LONG_TERM))
+    assert listed.success is True
+    assert len(listed.entries) >= 2
+    keys = {e.key for e in listed.entries}
+    assert "k1" in keys and "k2" in keys
+
+
+def test_memory_short_term_delete_unsupported(svc):
+    resp = svc.memory(
+        MemoryRequest(operation="delete", key="x", memory_type=MemoryType.SHORT_TERM)
+    )
+    assert resp.success is False
+    assert "clear" in (resp.error or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Knowledge — semantic retrieval
+# ---------------------------------------------------------------------------
+
+def test_query_semantic_empty_index(svc):
+    result = svc.query(
+        KnowledgeQuery(query_type=KnowledgeQueryType.SEMANTIC, text="anything", top_k=3)
+    )
+    assert isinstance(result, KnowledgeResult)
+    assert result.success is True
+    assert result.entries == []
+
+
+def test_query_semantic_with_documents(svc):
+    svc.add_document("d1", "The quick brown fox jumps over the lazy dog")
+    svc.add_document("d2", "Yasin-AI provides memory and knowledge services")
+    result = svc.query(
+        KnowledgeQuery(
+            query_type=KnowledgeQueryType.SEMANTIC,
+            text="memory knowledge",
+            top_k=5,
+        )
+    )
+    assert result.success is True
+    assert len(result.entries) >= 1
+    # highest relevance should mention memory/knowledge
+    top_content = str(result.entries[0].content).lower()
+    assert "memory" in top_content or "knowledge" in top_content or "yasin" in top_content
+
+
+# ---------------------------------------------------------------------------
+# Knowledge — graph / triple
+# ---------------------------------------------------------------------------
+
+def test_query_graph_neighbors(svc):
+    svc.add_triple("Alice", "knows", "Bob")
+    svc.add_triple("Alice", "works_at", "Yasin")
+    result = svc.query(
+        KnowledgeQuery(query_type=KnowledgeQueryType.GRAPH, subject="Alice")
+    )
+    assert result.success is True
+    assert len(result.entries) >= 2
+    entities = {e.content.get("entity") for e in result.entries if isinstance(e.content, dict)}
+    assert "Bob" in entities or "Yasin" in entities
+
+
+def test_query_triple(svc):
+    svc.add_triple("Python", "is_a", "language")
+    result = svc.query(
+        KnowledgeQuery(
+            query_type=KnowledgeQueryType.TRIPLE,
+            subject="Python",
+            predicate="is_a",
+        )
+    )
+    assert result.success is True
+    assert len(result.entries) >= 1
+    triple = result.entries[0].content
+    assert triple["subject"] == "Python"
+    assert triple["predicate"] == "is_a"
+    assert triple["object"] == "language"
+
+
+def test_query_reasoning(svc):
+    svc.add_triple("A", "related_to", "B")
+    svc.add_triple("B", "related_to", "C")
+    result = svc.query(
+        KnowledgeQuery(
+            query_type=KnowledgeQueryType.REASONING,
+            subject="A",
+            relation="related_to",
+        )
+    )
+    assert result.success is True
+    # At minimum neighbors or deduced results; success path is what we assert
+    assert isinstance(result.entries, list)
+
+
+# ---------------------------------------------------------------------------
+# Error / contract paths
+# ---------------------------------------------------------------------------
+
+def test_unsupported_memory_operation(svc):
+    # Bypass contract validation by constructing a raw-like call via internal path
+    # Contract forbids invalid ops, so we test the service defensive branch
+    # by calling with a mocked request that somehow got through.
+    class FakeReq:
+        operation = "flush"
+        memory_type = MemoryType.SHORT_TERM
+        key = None
+        content = None
+        limit = None
+        metadata = {}
+        context = None
+
+    resp = svc.memory(FakeReq())  # type: ignore[arg-type]
+    assert resp.success is False
+    assert "unsupported" in (resp.error or "").lower()
+
+
+def test_service_import_surface():
+    """Consumers import KnowledgeService from yasinai.services, not knowledge_platform."""
+    assert KS is KnowledgeService
+    from yasinai import services
+    assert hasattr(services, "KnowledgeService")

--- a/yasinai/services/__init__.py
+++ b/yasinai/services/__init__.py
@@ -1,0 +1,15 @@
+"""
+Yasin-AI Service Layer
+
+Thin facades that sit between public contracts (`yasinai.contracts`) and
+internal implementation packages (`knowledge_platform`, etc.).
+
+Consumers may import from here or from contracts; they must not import
+internal packages directly.
+"""
+
+from yasinai.services.knowledge_service import KnowledgeService
+
+__all__ = [
+    "KnowledgeService",
+]

--- a/yasinai/services/knowledge_service.py
+++ b/yasinai/services/knowledge_service.py
@@ -1,0 +1,299 @@
+"""
+KnowledgeService — facade over knowledge_platform for Memory & Knowledge.
+
+Phase 2.7: reconciles Memory / Knowledge / Retrieval boundaries.
+Consumers import this (or contracts) instead of knowledge_platform.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from yasinai.contracts.base import CapabilityMetadata
+from yasinai.contracts.knowledge import (
+    KnowledgeEntry,
+    KnowledgeQuery,
+    KnowledgeQueryType,
+    KnowledgeResult,
+)
+from yasinai.contracts.memory import (
+    MemoryEntry,
+    MemoryRequest,
+    MemoryResponse,
+    MemoryType,
+)
+
+logger = logging.getLogger(__name__)
+
+# Internal imports — only allowed inside the service layer
+from knowledge_platform.memory import MemoryManager
+from knowledge_platform.graph import KnowledgeGraph
+from knowledge_platform.semantic_search import Retriever
+from knowledge_platform.reasoning import KnowledgeReasoner
+
+
+class KnowledgeService:
+    """
+    Unified facade for memory operations and knowledge queries.
+
+    Owns (or accepts) the internal MemoryManager, KnowledgeGraph, and Retriever.
+    Translates public contracts to internal APIs and back.
+    """
+
+    def __init__(
+        self,
+        memory_manager: Optional[MemoryManager] = None,
+        knowledge_graph: Optional[KnowledgeGraph] = None,
+        retriever: Optional[Retriever] = None,
+        reasoner: Optional[KnowledgeReasoner] = None,
+    ) -> None:
+        self._memory = memory_manager or MemoryManager()
+        self._graph = knowledge_graph or KnowledgeGraph()
+        self._retriever = retriever or Retriever()
+        self._reasoner = reasoner  # lazy; created on first REASONING use if None
+
+    # ------------------------------------------------------------------
+    # Memory
+    # ------------------------------------------------------------------
+
+    def memory(self, request: MemoryRequest) -> MemoryResponse:
+        """Execute a memory operation described by MemoryRequest."""
+        meta = CapabilityMetadata(capability="memory")
+        try:
+            op = request.operation
+            if op == "store":
+                return self._memory_store(request, meta)
+            if op == "retrieve":
+                return self._memory_retrieve(request, meta)
+            if op == "delete":
+                return self._memory_delete(request, meta)
+            if op == "list":
+                return self._memory_list(request, meta)
+            if op == "clear":
+                return self._memory_clear(request, meta)
+            return MemoryResponse(
+                success=False,
+                error=f"Unsupported memory operation: {op}",
+                meta=meta,
+            )
+        except Exception as exc:  # noqa: BLE001 — facade must not leak internals
+            logger.exception("KnowledgeService.memory failed")
+            return MemoryResponse(success=False, error=str(exc), meta=meta)
+
+    def _memory_store(self, request: MemoryRequest, meta: CapabilityMetadata) -> MemoryResponse:
+        if request.memory_type == MemoryType.SHORT_TERM:
+            raw = self._memory.add_short_term(request.content, request.metadata or None)
+            entry = MemoryEntry(
+                content=raw["content"],
+                timestamp=raw["timestamp"],
+                key=None,
+                metadata=raw.get("metadata") or {},
+            )
+            return MemoryResponse(success=True, entry=entry, meta=meta)
+
+        # LONG_TERM
+        raw = self._memory.add_long_term(
+            request.key,  # type: ignore[arg-type]
+            request.content,
+            request.metadata or None,
+        )
+        entry = MemoryEntry(
+            content=raw["content"],
+            timestamp=raw["timestamp"],
+            key=raw.get("key") or request.key,
+            metadata=raw.get("metadata") or {},
+        )
+        return MemoryResponse(success=True, entry=entry, meta=meta)
+
+    def _memory_retrieve(self, request: MemoryRequest, meta: CapabilityMetadata) -> MemoryResponse:
+        if request.memory_type == MemoryType.SHORT_TERM:
+            raws = self._memory.get_short_term(limit=request.limit)
+            entries = [
+                MemoryEntry(
+                    content=r["content"],
+                    timestamp=r["timestamp"],
+                    key=None,
+                    metadata=r.get("metadata") or {},
+                )
+                for r in raws
+            ]
+            return MemoryResponse(success=True, entries=entries, meta=meta)
+
+        raw = self._memory.get_long_term(request.key)  # type: ignore[arg-type]
+        if raw is None:
+            return MemoryResponse(success=True, entry=None, meta=meta)
+        entry = MemoryEntry(
+            content=raw["content"],
+            timestamp=raw["timestamp"],
+            key=raw.get("key") or request.key,
+            metadata=raw.get("metadata") or {},
+        )
+        return MemoryResponse(success=True, entry=entry, meta=meta)
+
+    def _memory_delete(self, request: MemoryRequest, meta: CapabilityMetadata) -> MemoryResponse:
+        if request.memory_type == MemoryType.SHORT_TERM:
+            # Short-term has no key-based delete in the underlying manager;
+            # clear is the supported bulk operation.
+            return MemoryResponse(
+                success=False,
+                error="Short-term memory does not support key-based delete; use clear",
+                meta=meta,
+            )
+        deleted = self._memory.delete_long_term(request.key)  # type: ignore[arg-type]
+        return MemoryResponse(success=True, deleted=bool(deleted), meta=meta)
+
+    def _memory_list(self, request: MemoryRequest, meta: CapabilityMetadata) -> MemoryResponse:
+        if request.memory_type == MemoryType.SHORT_TERM:
+            raws = self._memory.get_short_term(limit=request.limit)
+            entries = [
+                MemoryEntry(
+                    content=r["content"],
+                    timestamp=r["timestamp"],
+                    key=None,
+                    metadata=r.get("metadata") or {},
+                )
+                for r in raws
+            ]
+            return MemoryResponse(success=True, entries=entries, meta=meta)
+
+        # list all long-term via the underlying store
+        raws = self._memory.long_term.list_all()
+        entries = [
+            MemoryEntry(
+                content=r["content"],
+                timestamp=r["timestamp"],
+                key=r.get("key"),
+                metadata=r.get("metadata") or {},
+            )
+            for r in raws
+        ]
+        if request.limit is not None:
+            entries = entries[: request.limit]
+        return MemoryResponse(success=True, entries=entries, meta=meta)
+
+    def _memory_clear(self, request: MemoryRequest, meta: CapabilityMetadata) -> MemoryResponse:
+        if request.memory_type == MemoryType.SHORT_TERM:
+            self._memory.short_term.clear()
+        elif request.memory_type == MemoryType.LONG_TERM:
+            self._memory.long_term.clear()
+        else:
+            self._memory.clear_all()
+        return MemoryResponse(success=True, meta=meta)
+
+    # ------------------------------------------------------------------
+    # Knowledge / Retrieval / Reasoning
+    # ------------------------------------------------------------------
+
+    def query(self, request: KnowledgeQuery) -> KnowledgeResult:
+        """Execute a knowledge query described by KnowledgeQuery."""
+        meta = CapabilityMetadata(capability="knowledge")
+        try:
+            qt = request.query_type
+            if qt == KnowledgeQueryType.SEMANTIC:
+                return self._query_semantic(request, meta)
+            if qt == KnowledgeQueryType.GRAPH:
+                return self._query_graph(request, meta)
+            if qt == KnowledgeQueryType.TRIPLE:
+                return self._query_triple(request, meta)
+            if qt == KnowledgeQueryType.REASONING:
+                return self._query_reasoning(request, meta)
+            return KnowledgeResult(
+                success=False,
+                error=f"Unsupported query_type: {qt}",
+                meta=meta,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("KnowledgeService.query failed")
+            return KnowledgeResult(success=False, error=str(exc), meta=meta)
+
+    def _query_semantic(self, request: KnowledgeQuery, meta: CapabilityMetadata) -> KnowledgeResult:
+        results = self._retriever.retrieve(request.text, limit=request.top_k)  # type: ignore[arg-type]
+        entries: List[KnowledgeEntry] = []
+        for item in results:
+            # Retriever returns dicts or objects depending on implementation
+            if isinstance(item, dict):
+                content = item.get("content") or item.get("text") or item
+                score = float(item.get("score", 1.0))
+                source = item.get("source") or item.get("id")
+                md = item.get("metadata") or {}
+            else:
+                content = getattr(item, "content", None) or getattr(item, "text", item)
+                score = float(getattr(item, "score", 1.0))
+                source = getattr(item, "source", None) or getattr(item, "id", None)
+                md = getattr(item, "metadata", {}) or {}
+            entries.append(
+                KnowledgeEntry(content=content, score=score, source=source, metadata=md)
+            )
+        return KnowledgeResult(success=True, entries=entries, meta=meta)
+
+    def _query_graph(self, request: KnowledgeQuery, meta: CapabilityMetadata) -> KnowledgeResult:
+        neighbors = self._graph.query_engine.find_neighbors(request.subject)  # type: ignore[arg-type]
+        entries = [
+            KnowledgeEntry(
+                content={"relation": rel, "entity": entity},
+                score=1.0,
+                source="graph",
+                metadata={"subject": request.subject},
+            )
+            for rel, entity in neighbors
+        ]
+        return KnowledgeResult(success=True, entries=entries, meta=meta)
+
+    def _query_triple(self, request: KnowledgeQuery, meta: CapabilityMetadata) -> KnowledgeResult:
+        triples = self._graph.triple_store.query_triples(
+            subject=request.subject,
+            predicate=request.predicate,
+        )
+        entries = [
+            KnowledgeEntry(
+                content={"subject": s, "predicate": p, "object": o},
+                score=1.0,
+                source="triple_store",
+            )
+            for s, p, o in triples
+        ]
+        return KnowledgeResult(success=True, entries=entries, meta=meta)
+
+    def _query_reasoning(self, request: KnowledgeQuery, meta: CapabilityMetadata) -> KnowledgeResult:
+        if self._reasoner is None:
+            self._reasoner = KnowledgeReasoner(self._graph)
+        results: List[Any] = []
+        # Prefer transitive deduction when a relation is supplied
+        if request.relation and hasattr(self._reasoner, "deduce_transitive_relations"):
+            try:
+                results = self._reasoner.deduce_transitive_relations(
+                    request.subject, request.relation  # type: ignore[arg-type]
+                )
+            except TypeError:
+                # Signature may accept only the graph; fall back to neighbors
+                results = []
+        if not results:
+            neighbors = self._graph.query_engine.find_neighbors(request.subject)  # type: ignore[arg-type]
+            results = [
+                {"relation": rel, "entity": ent}
+                for rel, ent in neighbors
+                if request.relation is None or rel == request.relation
+            ]
+
+        entries = [
+            KnowledgeEntry(
+                content=r if isinstance(r, dict) else {"value": r},
+                score=1.0,
+                source="reasoner",
+                metadata={"subject": request.subject, "relation": request.relation},
+            )
+            for r in (results or [])
+        ]
+        return KnowledgeResult(success=True, entries=entries, meta=meta)
+
+    # ------------------------------------------------------------------
+    # Convenience helpers used by tests / internal callers
+    # ------------------------------------------------------------------
+
+    def add_document(self, doc_id: str, text: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+        """Index a document into the semantic retriever."""
+        self._retriever.add_document(doc_id, text, metadata or {})
+
+    def add_triple(self, subject: str, predicate: str, obj: str) -> None:
+        """Add a triple to the knowledge graph."""
+        self._graph.add_triple(subject, predicate, obj)


### PR DESCRIPTION
## Phase 2.7 — Memory & Knowledge Architecture Reconciliation

### Changes
- **docs/MEMORY_KNOWLEDGE_ARCHITECTURE.md** — defines boundaries for Memory / Knowledge / Retrieval / RAG
- **yasinai/services/** — new service layer package with `KnowledgeService` facade
- **tests/test_knowledge_service.py** — 14 tests (all passing)
- **PROJECT_STATUS.md** — 2.7 marked COMPLETED, 2.8 NEXT

### Boundary rule
Consumers import from `yasinai.contracts` or `yasinai.services`; they must not import `knowledge_platform` directly.

### Test results
```
186 passed
```

### Next
Phase 2.8 — Foundation Tests, CI & Integration Readiness