### PR TITLE
fix(security): close Phase 15 audit findings (#51)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Yasin-AI environment template — copy to `.env` and fill values.
+# Never commit a real `.env` file.
+
+# Runtime
+ENVIRONMENT=development
+# YASINAI_MEMORY_PATH=~/.yasinai/memory.db
+# YASINAI_VECTOR_PATH=~/.yasinai/vectors.db
+
+# Provider credentials (Phase 3+) — read only from env, never from code
+# OPENAI_API_KEY=
+# ANTHROPIC_API_KEY=
+
+# Optional master key material for local SecretStore (hex, 64 chars for 256-bit)
+# YASINAI_MASTER_KEY=

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,28 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY pyproject.toml README.md ./
+# Install as non-root-ready layout; secrets must never be baked into the image.
+COPY pyproject.toml README.md LICENSE ./
 COPY yasinai ./yasinai
 COPY security_platform ./security_platform
 COPY developer_platform ./developer_platform
 COPY knowledge_platform ./knowledge_platform
+COPY api_service ./api_service
+COPY observability ./observability
 
 RUN python -m pip install --no-cache-dir --upgrade pip \
     && python -m pip install --no-cache-dir . \
     && useradd --system --uid 10001 --no-create-home yasinai \
     && chown -R yasinai:yasinai /app
 
-COPY . .
-RUN chown -R yasinai:yasinai /app
+# Remaining repo files (docs, deploy metadata) — no .env / credentials (gitignored)
+COPY --chown=yasinai:yasinai . .
 
 USER 10001:10001
 
 EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+  CMD yasin status || exit 1
 
 CMD ["yasin", "status"]

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -249,3 +249,4 @@ End of Project Status
 | 2.6 Provider Architecture Audit | COMPLETED — yasinai/providers/ boundary, 23 tests, 2026-08-14 |
 | 2.7 Memory & Knowledge Architecture Reconciliation | COMPLETED — docs/MEMORY_KNOWLEDGE_ARCHITECTURE.md, yasinai/services/KnowledgeService, 14 tests |
 | 2.8 Foundation Tests, CI & Integration Readiness | COMPLETED — coverage 94%+, CI fail-under=85, sdk+entrypoint tests, observability in cov |
+| 15 Security audit closure (#51) | COMPLETED — re-verified 2026-08-14, residual risks documented |

--- a/SECURITY_AUDIT_2026-08-09.md
+++ b/SECURITY_AUDIT_2026-08-09.md
@@ -27,3 +27,32 @@ Repository configuration, CI security gates, secret handling policy, container h
 ## Release gate
 
 This audit is a repository review, not a penetration test or formal security certification. Release-candidate work must not remove these boundaries without adding an equivalent tested control.
+
+---
+
+## Re-verification — 2026-08-14 (closes #51)
+
+Phase 2 reconciliation and post-release maintenance were completed. Issue #51
+tracks final audit remediation; the following in-repo items were re-checked
+and closed:
+
+| Check | Evidence |
+|---|---|
+| `SecurityScanner` local scan | `status=SECURE`, `failed_items=0` |
+| CI security job | `pip-audit`, secret-file ban, `yasin security check` |
+| Coverage / test gate | CI `cov-fail-under=85` (Phase 2.8) |
+| Non-root container | Dockerfile `USER 10001:10001` + `HEALTHCHECK` |
+| Production compose | `deploy/compose.production.yml`: `read_only`, `cap_drop: ALL`, `no-new-privileges`, data volume |
+| Dev compose baseline | Root `docker-compose.yml`: `cap_drop`, `no-new-privileges`, healthcheck |
+| Secret templates | `.env.example` present; real `.env` / `*.key` / `*.pem` gitignored |
+| Plugin trust | Documented in `SECURITY.md` and this audit — no sandbox claimed |
+| Crypto | AES-256-GCM via `cryptography` AEAD; regression tests present |
+
+### Residual risks (unchanged — out of repository scope)
+
+1. In-process plugins are not sandboxed (trusted-code only).
+2. Session/auth state is process-local, not a distributed store.
+3. Network policy, external secret managers, and host hardening remain operator responsibilities.
+
+**Disposition:** Issue #51 closed. No further in-repo remediation required for the
+v1.1.0 maintenance line under the stated residual risks.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,7 @@
-version: '3.8'
+version: "3.8"
+
+# Development-oriented compose. For production hardening use:
+#   docker compose -f deploy/compose.production.yml up
 
 services:
   yasinai:
@@ -7,4 +10,18 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - ENVIRONMENT=production
+      - ENVIRONMENT=development
+    # Local hardening baseline (production profile is stricter)
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: false
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=64m
+    healthcheck:
+      test: ["CMD", "yasin", "status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s


### PR DESCRIPTION
## Closes #51 — Phase 15 final security audit findings

### Remediation
- `.env.example` (template only; real secrets stay gitignored)
- Root `docker-compose.yml`: `cap_drop: ALL`, `no-new-privileges`, healthcheck
- `Dockerfile`: full package COPY, non-root `USER 10001`, `HEALTHCHECK`
- `SECURITY_AUDIT_2026-08-09.md`: 2026-08-14 re-verification table
- Local `SecurityScanner`: **SECURE / failed_items=0**

Residual risks (plugins in-process, process-local sessions, external infra) remain documented and out of pure in-repo scope.