### PR TITLE
feat(phase-3.1): concrete provider adapters (OpenAI, Anthropic, Local)

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -250,3 +250,4 @@ End of Project Status
 | 2.7 Memory & Knowledge Architecture Reconciliation | COMPLETED — docs/MEMORY_KNOWLEDGE_ARCHITECTURE.md, yasinai/services/KnowledgeService, 14 tests |
 | 2.8 Foundation Tests, CI & Integration Readiness | COMPLETED — coverage 94%+, CI fail-under=85, sdk+entrypoint tests, observability in cov |
 | 15 Security audit closure (#51) | COMPLETED — re-verified 2026-08-14, residual risks documented |
+| 3.1 Concrete Provider Adapters (#68) | COMPLETED — OpenAI, Anthropic, Local + factory + tests |

--- a/docs/PROVIDER_ARCHITECTURE.md
+++ b/docs/PROVIDER_ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Yasin-AI — Provider Architecture
 
 **Phase:** 2.6  
-**Status:** Boundary defined. Concrete providers: Phase 3.  
+**Status:** Phase 3.1 complete — OpenAI, Anthropic, Local adapters implemented.  
 **Date:** 2026-08-14
 
 ---

--- a/tests/test_concrete_providers.py
+++ b/tests/test_concrete_providers.py
@@ -1,0 +1,190 @@
+"""Tests for Phase 3.1 concrete provider adapters (mocked transport, no live API)."""
+from __future__ import annotations
+
+import pytest
+
+from yasinai.providers import (
+    AnthropicProvider,
+    LocalProvider,
+    OpenAIProvider,
+    ProviderCapability,
+    ProviderError,
+    ProviderRegistry,
+    ProviderRouter,
+    build_default_registry,
+)
+from yasinai.providers.base import GenerationRequest
+from yasinai.providers.router import ProviderUnavailableError
+
+
+# ---------------------------------------------------------------------------
+# LocalProvider
+# ---------------------------------------------------------------------------
+
+def test_local_always_available():
+    p = LocalProvider()
+    assert p.is_available() is True
+    assert p.info.name == "local"
+    assert ProviderCapability.GENERATION in p.info.capabilities
+
+
+def test_local_generate_echo():
+    p = LocalProvider()
+    resp = p.generate(GenerationRequest(prompt="hello world", max_tokens=50))
+    assert resp.provider == "local"
+    assert "hello world" in resp.text
+    assert resp.model == "local-echo-v1"
+    assert resp.input_tokens >= 1
+    assert resp.output_tokens >= 1
+
+
+def test_local_system_prompt_and_stop():
+    p = LocalProvider()
+    resp = p.generate(
+        GenerationRequest(
+            prompt="abcSTOP more",
+            system_prompt="sys",
+            stop_sequences=["STOP"],
+            max_tokens=100,
+        )
+    )
+    assert "[system: sys]" in resp.text
+    assert " more" not in resp.text
+    assert "STOP" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# OpenAIProvider
+# ---------------------------------------------------------------------------
+
+def test_openai_unavailable_without_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    p = OpenAIProvider()
+    assert p.is_available() is False
+
+
+def test_openai_available_with_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+    p = OpenAIProvider()
+    assert p.is_available() is True
+    assert p.info.name == "openai"
+    assert "gpt-4o" in p.info.model_ids
+
+
+def test_openai_generate_with_mock_transport():
+    def transport(url, headers, body):
+        assert "chat/completions" in url
+        assert headers["Authorization"].startswith("Bearer ")
+        assert body["messages"][-1]["content"] == "ping"
+        return {
+            "id": "chatcmpl-1",
+            "model": "gpt-4o-mini",
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "pong"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1},
+        }
+
+    p = OpenAIProvider(api_key="sk-test", transport=transport)
+    resp = p.generate(GenerationRequest(prompt="ping", model="gpt-4o-mini"))
+    assert resp.text == "pong"
+    assert resp.provider == "openai"
+    assert resp.input_tokens == 3
+    assert resp.output_tokens == 1
+    assert resp.finish_reason == "stop"
+
+
+def test_openai_missing_key_raises():
+    p = OpenAIProvider(api_key="")
+    with pytest.raises(ProviderError, match="OPENAI_API_KEY"):
+        p.generate(GenerationRequest(prompt="x"))
+
+
+def test_openai_bad_response_shape():
+    def transport(url, headers, body):
+        return {"choices": []}
+
+    p = OpenAIProvider(api_key="sk-test", transport=transport)
+    with pytest.raises(ProviderError, match="Unexpected response"):
+        p.generate(GenerationRequest(prompt="x"))
+
+
+# ---------------------------------------------------------------------------
+# AnthropicProvider
+# ---------------------------------------------------------------------------
+
+def test_anthropic_unavailable_without_key(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    p = AnthropicProvider()
+    assert p.is_available() is False
+
+
+def test_anthropic_generate_with_mock_transport():
+    def transport(url, headers, body):
+        assert url.endswith("/v1/messages")
+        assert "x-api-key" in headers
+        assert body["messages"][0]["content"] == "hi"
+        return {
+            "id": "msg_1",
+            "model": "claude-3-5-haiku-latest",
+            "content": [{"type": "text", "text": "hello"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 2, "output_tokens": 1},
+        }
+
+    p = AnthropicProvider(api_key="ant-test", transport=transport)
+    resp = p.generate(GenerationRequest(prompt="hi"))
+    assert resp.text == "hello"
+    assert resp.provider == "anthropic"
+    assert resp.finish_reason == "end_turn"
+
+
+def test_anthropic_missing_key_raises():
+    p = AnthropicProvider(api_key="")
+    with pytest.raises(ProviderError, match="ANTHROPIC_API_KEY"):
+        p.generate(GenerationRequest(prompt="x"))
+
+
+# ---------------------------------------------------------------------------
+# Registry / Router integration
+# ---------------------------------------------------------------------------
+
+def test_build_default_registry_local_only(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    reg = build_default_registry()
+    assert len(reg) == 3  # all registered
+    available = reg.available_for_capability(ProviderCapability.GENERATION)
+    names = {p.info.name for p in available}
+    assert names == {"local"}
+
+
+def test_router_selects_openai_when_key_present(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    reg = build_default_registry()
+    router = ProviderRouter(reg)
+    provider = router.select(ProviderCapability.GENERATION, model="gpt-4o")
+    assert provider.info.name == "openai"
+
+
+def test_router_falls_back_to_local(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    reg = ProviderRegistry()
+    reg.register(LocalProvider())
+    router = ProviderRouter(reg)
+    provider = router.select(ProviderCapability.GENERATION)
+    assert provider.info.name == "local"
+
+
+def test_router_unavailable(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    reg = ProviderRegistry()
+    reg.register(OpenAIProvider())  # not available
+    router = ProviderRouter(reg)
+    with pytest.raises(ProviderUnavailableError):
+        router.select(ProviderCapability.GENERATION)

--- a/yasinai/providers/__init__.py
+++ b/yasinai/providers/__init__.py
@@ -6,14 +6,13 @@ It contains:
   - The public ProviderBase interface (all providers implement this)
   - The ProviderRegistry (single registry, per-Runtime instance)
   - The ProviderRouter (select provider by capability/model hint)
-  - Provider-specific adapters (Phase 3 — not yet implemented)
+  - Concrete adapters: OpenAI, Anthropic, Local (Phase 3.1)
 
-STATUS: Phase 2.6 — boundary defined.
-        Phase 3 will implement concrete providers (OpenAI, Anthropic, local).
+STATUS: Phase 3.1 — concrete providers implemented.
 
-Usage (Phase 3+):
-    from yasinai.providers import ProviderRegistry, ProviderRouter
-    from yasinai.providers.base import ProviderBase, GenerationRequest, GenerationResponse
+Usage:
+    from yasinai.providers import ProviderRegistry, ProviderRouter, build_default_registry
+    from yasinai.providers.base import GenerationRequest, GenerationResponse
 """
 
 from yasinai.providers.base import (
@@ -22,9 +21,14 @@ from yasinai.providers.base import (
     ProviderInfo,
     GenerationRequest,
     GenerationResponse,
+    ProviderError,
 )
 from yasinai.providers.registry import ProviderRegistry
 from yasinai.providers.router import ProviderRouter
+from yasinai.providers.factory import build_default_registry, register_default_providers
+from yasinai.providers.local_provider import LocalProvider
+from yasinai.providers.openai_provider import OpenAIProvider
+from yasinai.providers.anthropic_provider import AnthropicProvider
 
 __all__ = [
     "ProviderBase",
@@ -32,6 +36,12 @@ __all__ = [
     "ProviderInfo",
     "GenerationRequest",
     "GenerationResponse",
+    "ProviderError",
     "ProviderRegistry",
     "ProviderRouter",
+    "LocalProvider",
+    "OpenAIProvider",
+    "AnthropicProvider",
+    "build_default_registry",
+    "register_default_providers",
 ]

--- a/yasinai/providers/anthropic_provider.py
+++ b/yasinai/providers/anthropic_provider.py
@@ -1,0 +1,146 @@
+"""
+AnthropicProvider — Anthropic Messages API adapter.
+
+Credentials: ANTHROPIC_API_KEY only (never hardcoded).
+SDK libraries are not required at import time; HTTP transport is injectable.
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Dict, Optional
+
+from yasinai.providers.base import (
+    GenerationRequest,
+    GenerationResponse,
+    ProviderBase,
+    ProviderCapability,
+    ProviderError,
+    ProviderInfo,
+)
+
+HttpTransport = Callable[[str, Dict[str, str], Dict[str, Any]], Dict[str, Any]]
+
+DEFAULT_BASE_URL = "https://api.anthropic.com"
+DEFAULT_MODEL = "claude-3-5-haiku-latest"
+ANTHROPIC_VERSION = "2023-06-01"
+
+
+def _default_http_transport(
+    url: str, headers: Dict[str, str], body: Dict[str, Any]
+) -> Dict[str, Any]:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise ProviderError(
+            "anthropic", f"HTTP {exc.code}: {detail}", retryable=exc.code >= 500
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise ProviderError("anthropic", f"Network error: {exc}", retryable=True) from exc
+
+
+class AnthropicProvider(ProviderBase):
+    """Anthropic Messages API adapter."""
+
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        default_model: str = DEFAULT_MODEL,
+        transport: Optional[HttpTransport] = None,
+    ) -> None:
+        self._api_key_override = api_key
+        self._base_url = (base_url or DEFAULT_BASE_URL).rstrip("/")
+        self._default_model = default_model
+        self._transport = transport or _default_http_transport
+
+    def _api_key(self) -> Optional[str]:
+        return self._api_key_override or os.environ.get("ANTHROPIC_API_KEY")
+
+    @property
+    def info(self) -> ProviderInfo:
+        return ProviderInfo(
+            name="anthropic",
+            version="1.0.0",
+            capabilities=[
+                ProviderCapability.GENERATION,
+                ProviderCapability.CHAT,
+            ],
+            model_ids=[
+                "claude-3-5-sonnet-latest",
+                "claude-3-5-haiku-latest",
+                "claude-3-opus-latest",
+                "claude-3-sonnet-20240229",
+                "claude-3-haiku-20240307",
+            ],
+            metadata={"env_key": "ANTHROPIC_API_KEY", "base_url": self._base_url},
+        )
+
+    def is_available(self) -> bool:
+        return bool(self._api_key())
+
+    def _generate(self, request: GenerationRequest) -> GenerationResponse:
+        key = self._api_key()
+        if not key:
+            raise ProviderError(
+                "anthropic",
+                "ANTHROPIC_API_KEY is not set",
+                retryable=False,
+            )
+        model = request.model or self._default_model
+        body: Dict[str, Any] = {
+            "model": model,
+            "max_tokens": request.max_tokens,
+            "temperature": request.temperature,
+            "messages": [{"role": "user", "content": request.prompt}],
+        }
+        if request.system_prompt:
+            body["system"] = request.system_prompt
+        if request.stop_sequences:
+            body["stop_sequences"] = request.stop_sequences
+
+        headers = {
+            "x-api-key": key,
+            "anthropic-version": ANTHROPIC_VERSION,
+            "Content-Type": "application/json",
+        }
+        url = f"{self._base_url}/v1/messages"
+
+        try:
+            payload = self._transport(url, headers, body)
+        except ProviderError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise ProviderError("anthropic", str(exc), retryable=True) from exc
+
+        try:
+            blocks = payload.get("content") or []
+            text_parts = [
+                b.get("text", "") for b in blocks if isinstance(b, dict) and b.get("type") == "text"
+            ]
+            text = "".join(text_parts)
+            usage = payload.get("usage") or {}
+            finish = payload.get("stop_reason")
+        except (TypeError, AttributeError) as exc:
+            raise ProviderError(
+                "anthropic",
+                f"Unexpected response shape: {payload!r}",
+                retryable=False,
+            ) from exc
+
+        return GenerationResponse(
+            text=text,
+            model=payload.get("model") or model,
+            provider="anthropic",
+            input_tokens=int(usage.get("input_tokens") or 0),
+            output_tokens=int(usage.get("output_tokens") or 0),
+            finish_reason=finish,
+            metadata={"id": payload.get("id")},
+        )

--- a/yasinai/providers/factory.py
+++ b/yasinai/providers/factory.py
@@ -1,0 +1,37 @@
+"""
+Provider factory helpers — register default adapters into a registry.
+
+Does not import any third-party SDK at module level.
+"""
+from __future__ import annotations
+
+from yasinai.providers.anthropic_provider import AnthropicProvider
+from yasinai.providers.local_provider import LocalProvider
+from yasinai.providers.openai_provider import OpenAIProvider
+from yasinai.providers.registry import ProviderRegistry
+
+
+def register_default_providers(
+    registry: ProviderRegistry,
+    *,
+    include_local: bool = True,
+    include_openai: bool = True,
+    include_anthropic: bool = True,
+    overwrite: bool = False,
+) -> ProviderRegistry:
+    """
+    Register built-in providers. Availability is determined at call time
+    via each provider's ``is_available()`` (env keys).
+    """
+    if include_local:
+        registry.register(LocalProvider(), overwrite=overwrite)
+    if include_openai:
+        registry.register(OpenAIProvider(), overwrite=overwrite)
+    if include_anthropic:
+        registry.register(AnthropicProvider(), overwrite=overwrite)
+    return registry
+
+
+def build_default_registry(**kwargs) -> ProviderRegistry:
+    """Create a new registry and register default providers."""
+    return register_default_providers(ProviderRegistry(), **kwargs)

--- a/yasinai/providers/local_provider.py
+++ b/yasinai/providers/local_provider.py
@@ -1,0 +1,66 @@
+"""
+LocalProvider — offline generation adapter (no network, no external SDK).
+
+Always available. Useful for tests, CI, and air-gapped environments.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from yasinai.providers.base import (
+    GenerationRequest,
+    GenerationResponse,
+    ProviderBase,
+    ProviderCapability,
+    ProviderInfo,
+)
+
+
+class LocalProvider(ProviderBase):
+    """Deterministic local stub that echoes structured completions."""
+
+    DEFAULT_MODEL = "local-echo-v1"
+
+    def __init__(self, *, model_id: Optional[str] = None) -> None:
+        self._model_id = model_id or self.DEFAULT_MODEL
+
+    @property
+    def info(self) -> ProviderInfo:
+        return ProviderInfo(
+            name="local",
+            version="1.0.0",
+            capabilities=[
+                ProviderCapability.GENERATION,
+                ProviderCapability.CHAT,
+            ],
+            model_ids=[self._model_id],
+            metadata={"network": False, "sdk": None},
+        )
+
+    def is_available(self) -> bool:
+        return True
+
+    def _generate(self, request: GenerationRequest) -> GenerationResponse:
+        model = request.model or self._model_id
+        system = request.system_prompt or ""
+        prefix = f"[system: {system}] " if system else ""
+        text = (
+            f"{prefix}[local:{model}] "
+            f"{request.prompt[: max(1, request.max_tokens)]}"
+        )
+        if request.stop_sequences:
+            for stop in request.stop_sequences:
+                if stop and stop in text:
+                    text = text.split(stop, 1)[0]
+                    break
+        # Rough token estimate: ~4 chars per token
+        in_tok = max(1, len(request.prompt) // 4)
+        out_tok = max(1, len(text) // 4)
+        return GenerationResponse(
+            text=text,
+            model=model,
+            provider="local",
+            input_tokens=in_tok,
+            output_tokens=out_tok,
+            metadata={"temperature": request.temperature},
+        )

--- a/yasinai/providers/openai_provider.py
+++ b/yasinai/providers/openai_provider.py
@@ -1,0 +1,147 @@
+"""
+OpenAIProvider — OpenAI Chat Completions adapter.
+
+Credentials: OPENAI_API_KEY only (never hardcoded).
+SDK libraries are imported inside call methods, not at module level.
+HTTP transport is injectable for unit tests (no live API required).
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Dict, Optional
+
+from yasinai.providers.base import (
+    GenerationRequest,
+    GenerationResponse,
+    ProviderBase,
+    ProviderCapability,
+    ProviderError,
+    ProviderInfo,
+)
+
+# Optional injectable transport: (url, headers, body_dict) -> response_dict
+HttpTransport = Callable[[str, Dict[str, str], Dict[str, Any]], Dict[str, Any]]
+
+DEFAULT_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_MODEL = "gpt-4o-mini"
+
+
+def _default_http_transport(
+    url: str, headers: Dict[str, str], body: Dict[str, Any]
+) -> Dict[str, Any]:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise ProviderError("openai", f"HTTP {exc.code}: {detail}", retryable=exc.code >= 500) from exc
+    except urllib.error.URLError as exc:
+        raise ProviderError("openai", f"Network error: {exc}", retryable=True) from exc
+
+
+class OpenAIProvider(ProviderBase):
+    """OpenAI adapter using Chat Completions API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        default_model: str = DEFAULT_MODEL,
+        transport: Optional[HttpTransport] = None,
+    ) -> None:
+        # api_key arg is for tests only; production uses env
+        self._api_key_override = api_key
+        self._base_url = (base_url or DEFAULT_BASE_URL).rstrip("/")
+        self._default_model = default_model
+        self._transport = transport or _default_http_transport
+
+    def _api_key(self) -> Optional[str]:
+        return self._api_key_override or os.environ.get("OPENAI_API_KEY")
+
+    @property
+    def info(self) -> ProviderInfo:
+        return ProviderInfo(
+            name="openai",
+            version="1.0.0",
+            capabilities=[
+                ProviderCapability.GENERATION,
+                ProviderCapability.CHAT,
+                ProviderCapability.EMBEDDING,
+            ],
+            model_ids=[
+                "gpt-4o",
+                "gpt-4o-mini",
+                "gpt-4-turbo",
+                "gpt-3.5-turbo",
+                "text-embedding-3-small",
+                "text-embedding-3-large",
+            ],
+            metadata={"env_key": "OPENAI_API_KEY", "base_url": self._base_url},
+        )
+
+    def is_available(self) -> bool:
+        return bool(self._api_key())
+
+    def _generate(self, request: GenerationRequest) -> GenerationResponse:
+        key = self._api_key()
+        if not key:
+            raise ProviderError(
+                "openai",
+                "OPENAI_API_KEY is not set",
+                retryable=False,
+            )
+        model = request.model or self._default_model
+        messages = []
+        if request.system_prompt:
+            messages.append({"role": "system", "content": request.system_prompt})
+        messages.append({"role": "user", "content": request.prompt})
+
+        body: Dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": request.max_tokens,
+            "temperature": request.temperature,
+        }
+        if request.stop_sequences:
+            body["stop"] = request.stop_sequences
+
+        headers = {
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+        }
+        url = f"{self._base_url}/chat/completions"
+
+        try:
+            payload = self._transport(url, headers, body)
+        except ProviderError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — boundary: never leak transport errors
+            raise ProviderError("openai", str(exc), retryable=True) from exc
+
+        try:
+            choice = payload["choices"][0]
+            text = choice["message"]["content"]
+            usage = payload.get("usage") or {}
+            finish = choice.get("finish_reason")
+        except (KeyError, IndexError, TypeError) as exc:
+            raise ProviderError(
+                "openai",
+                f"Unexpected response shape: {payload!r}",
+                retryable=False,
+            ) from exc
+
+        return GenerationResponse(
+            text=text or "",
+            model=payload.get("model") or model,
+            provider="openai",
+            input_tokens=int(usage.get("prompt_tokens") or 0),
+            output_tokens=int(usage.get("completion_tokens") or 0),
+            finish_reason=finish,
+            metadata={"id": payload.get("id")},
+        )


### PR DESCRIPTION
## Closes #68

- LocalProvider (offline)
- OpenAIProvider (`OPENAI_API_KEY`)
- AnthropicProvider (`ANTHROPIC_API_KEY`)
- `build_default_registry()`
- Mocked transport tests — **214 passed**
- No third-party SDKs required at install time