### PR TITLE
feat(phase-3.2): generation service facade and public contracts

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -251,3 +251,4 @@ End of Project Status
 | 2.8 Foundation Tests, CI & Integration Readiness | COMPLETED — coverage 94%+, CI fail-under=85, sdk+entrypoint tests, observability in cov |
 | 15 Security audit closure (#51) | COMPLETED — re-verified 2026-08-14, residual risks documented |
 | 3.1 Concrete Provider Adapters (#68) | COMPLETED — OpenAI, Anthropic, Local + factory + tests |
+| 3.2 Generation Service Facade (#69) | COMPLETED — GenerationRequest/Result contracts + GenerationService |

--- a/docs/CAPABILITY_CONTRACTS_V1.md
+++ b/docs/CAPABILITY_CONTRACTS_V1.md
@@ -116,8 +116,8 @@ Covers cross-repo plugin invocation.
 The following capability contracts are **PLANNED** and will be added in Phase 3
 once the provider gateway exists:
 
-- `GenerationRequest / GenerationResponse` (requires LLM provider)
-- `ChatRequest / ChatResponse` (requires LLM provider)
+- `GenerationRequest / GenerationResult` — **available** (Phase 3.2; via GenerationService)
+- `ChatRequest / ChatResponse` (deferred; use GenerationRequest with system_prompt)
 - `SummarizationRequest / SummarizationResponse`
 - `ClassificationRequest / ClassificationResponse`
 - `RAGRequest / RAGResponse` (requires unified pipeline)

--- a/tests/test_generation_service.py
+++ b/tests/test_generation_service.py
@@ -1,0 +1,78 @@
+"""Tests for Generation contract + GenerationService (Phase 3.2)."""
+from __future__ import annotations
+
+import pytest
+
+from yasinai.contracts import GenerationRequest, GenerationResult, ContractViolationError
+from yasinai.providers import LocalProvider, OpenAIProvider, ProviderRegistry
+from yasinai.services import GenerationService
+
+
+def test_generation_request_validation():
+    with pytest.raises(ContractViolationError, match="prompt"):
+        GenerationRequest(prompt="")
+    with pytest.raises(ContractViolationError, match="temperature"):
+        GenerationRequest(prompt="hi", temperature=3.0)
+    with pytest.raises(ContractViolationError, match="max_tokens"):
+        GenerationRequest(prompt="hi", max_tokens=0)
+
+
+def test_generate_via_local_provider():
+    reg = ProviderRegistry()
+    reg.register(LocalProvider())
+    svc = GenerationService(registry=reg)
+    result = svc.generate(GenerationRequest(prompt="hello phase 3.2"))
+    assert isinstance(result, GenerationResult)
+    assert result.success is True
+    assert "hello phase 3.2" in result.text
+    assert result.provider == "local"
+    assert result.meta.capability == "generation"
+    assert result.meta.provider == "local"
+
+
+def test_generate_preferred_provider():
+    reg = ProviderRegistry()
+    reg.register(LocalProvider())
+    svc = GenerationService(registry=reg)
+    result = svc.generate(
+        GenerationRequest(prompt="ping", provider="local", system_prompt="sys")
+    )
+    assert result.success is True
+    assert result.provider == "local"
+    assert "[system: sys]" in result.text
+
+
+def test_generate_unavailable_provider():
+    reg = ProviderRegistry()
+    reg.register(OpenAIProvider(api_key=""))  # not available
+    svc = GenerationService(registry=reg)
+    result = svc.generate(GenerationRequest(prompt="x"))
+    assert result.success is False
+    assert result.error
+    assert "provider" in result.error.lower() or "No available" in result.error
+
+
+def test_generate_unknown_named_provider():
+    reg = ProviderRegistry()
+    reg.register(LocalProvider())
+    svc = GenerationService(registry=reg)
+    result = svc.generate(GenerationRequest(prompt="x", provider="does-not-exist"))
+    assert result.success is False
+
+
+def test_default_registry_includes_local(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    svc = GenerationService()
+    result = svc.generate(GenerationRequest(prompt="offline ok"))
+    assert result.success is True
+    assert result.provider == "local"
+
+
+def test_service_import_surface():
+    from yasinai import services
+    from yasinai import contracts
+
+    assert hasattr(services, "GenerationService")
+    assert hasattr(contracts, "GenerationRequest")
+    assert hasattr(contracts, "GenerationResult")

--- a/yasinai/contracts/__init__.py
+++ b/yasinai/contracts/__init__.py
@@ -37,6 +37,10 @@ from yasinai.contracts.plugin import (
     PluginInvokeRequest,
     PluginInvokeResponse,
 )
+from yasinai.contracts.generation import (
+    GenerationRequest,
+    GenerationResult,
+)
 
 __all__ = [
     # base
@@ -63,6 +67,9 @@ __all__ = [
     "PluginContract",
     "PluginInvokeRequest",
     "PluginInvokeResponse",
+    # generation
+    "GenerationRequest",
+    "GenerationResult",
 ]
 
 CONTRACT_VERSION = "v1"

--- a/yasinai/contracts/generation.py
+++ b/yasinai/contracts/generation.py
@@ -1,0 +1,85 @@
+"""
+Generation Capability Contract v1
+
+Stable interface for text/chat generation.
+Backed by yasinai.services.GenerationService → ProviderRouter.
+Consumers must not import yasinai.providers directly.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from yasinai.contracts.base import (
+    CapabilityMetadata,
+    ContractViolationError,
+    ObservabilityContext,
+)
+
+
+@dataclass(frozen=True)
+class GenerationRequest:
+    """
+    Input contract for text generation.
+
+    Attributes:
+        prompt:          User prompt (required, non-empty)
+        model:           Optional model hint for routing
+        max_tokens:      Max tokens to generate (default 1024)
+        temperature:     Sampling temperature 0.0–2.0 (default 0.7)
+        system_prompt:   Optional system instruction
+        stop_sequences:  Optional stop strings
+        provider:        Optional preferred provider name (e.g. openai, local)
+        metadata:        Caller-supplied context
+        context:         Observability tracing context
+    """
+
+    prompt: str
+    model: Optional[str] = None
+    max_tokens: int = 1024
+    temperature: float = 0.7
+    system_prompt: Optional[str] = None
+    stop_sequences: List[str] = field(default_factory=list)
+    provider: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    context: Optional[ObservabilityContext] = None
+
+    def __post_init__(self) -> None:
+        if not self.prompt or not str(self.prompt).strip():
+            raise ContractViolationError("GenerationRequest: 'prompt' must not be empty")
+        if not 0.0 <= self.temperature <= 2.0:
+            raise ContractViolationError(
+                "GenerationRequest: 'temperature' must be between 0.0 and 2.0"
+            )
+        if self.max_tokens < 1:
+            raise ContractViolationError("GenerationRequest: 'max_tokens' must be >= 1")
+
+
+@dataclass(frozen=True)
+class GenerationResult:
+    """
+    Output contract for a generation call.
+
+    Attributes:
+        success:        True if generation completed without error
+        text:           Generated text (empty on failure)
+        model:          Model id that produced the text
+        provider:       Provider name that handled the request
+        input_tokens:   Estimated/reported input tokens
+        output_tokens:  Estimated/reported output tokens
+        finish_reason:  Provider finish reason if available
+        error:          Error message if success is False
+        meta:           Capability metadata
+    """
+
+    success: bool
+    text: str = ""
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    finish_reason: Optional[str] = None
+    error: Optional[str] = None
+    meta: CapabilityMetadata = field(
+        default_factory=lambda: CapabilityMetadata(capability="generation")
+    )

--- a/yasinai/services/__init__.py
+++ b/yasinai/services/__init__.py
@@ -2,14 +2,16 @@
 Yasin-AI Service Layer
 
 Thin facades that sit between public contracts (`yasinai.contracts`) and
-internal implementation packages (`knowledge_platform`, etc.).
+internal implementation packages (`knowledge_platform`, `yasinai.providers`).
 
 Consumers may import from here or from contracts; they must not import
 internal packages directly.
 """
 
 from yasinai.services.knowledge_service import KnowledgeService
+from yasinai.services.generation_service import GenerationService
 
 __all__ = [
     "KnowledgeService",
+    "GenerationService",
 ]

--- a/yasinai/services/generation_service.py
+++ b/yasinai/services/generation_service.py
@@ -1,0 +1,110 @@
+"""
+GenerationService — facade over ProviderRouter for text generation.
+
+Phase 3.2: consumers call this (or contracts) instead of yasinai.providers.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from yasinai.contracts.base import CapabilityMetadata
+from yasinai.contracts.generation import GenerationRequest, GenerationResult
+from yasinai.providers.base import (
+    GenerationRequest as ProviderGenerationRequest,
+    ProviderCapability,
+    ProviderError,
+)
+from yasinai.providers.factory import build_default_registry
+from yasinai.providers.registry import ProviderRegistry
+from yasinai.providers.router import ProviderRouter, ProviderUnavailableError
+
+logger = logging.getLogger(__name__)
+
+
+class GenerationService:
+    """
+    Public generation facade.
+
+    Routes GenerationRequest contracts through ProviderRouter to a concrete
+    provider adapter. Never imports provider SDKs.
+    """
+
+    def __init__(
+        self,
+        registry: Optional[ProviderRegistry] = None,
+        router: Optional[ProviderRouter] = None,
+        *,
+        default_capability: ProviderCapability = ProviderCapability.GENERATION,
+    ) -> None:
+        self._registry = registry or build_default_registry()
+        self._router = router or ProviderRouter(self._registry)
+        self._default_capability = default_capability
+
+    def generate(self, request: GenerationRequest) -> GenerationResult:
+        """Execute a generation request; always returns GenerationResult."""
+        meta = CapabilityMetadata(capability="generation")
+        try:
+            provider = self._select_provider(request)
+            internal = ProviderGenerationRequest(
+                prompt=request.prompt,
+                model=request.model,
+                max_tokens=request.max_tokens,
+                temperature=request.temperature,
+                system_prompt=request.system_prompt,
+                stop_sequences=list(request.stop_sequences or []),
+                metadata=dict(request.metadata or {}),
+            )
+            response = provider.generate(internal)
+            return GenerationResult(
+                success=True,
+                text=response.text,
+                model=response.model,
+                provider=response.provider,
+                input_tokens=response.input_tokens,
+                output_tokens=response.output_tokens,
+                finish_reason=response.finish_reason,
+                meta=CapabilityMetadata(
+                    capability="generation",
+                    provider=response.provider,
+                ),
+            )
+        except ProviderUnavailableError as exc:
+            logger.warning("Generation unavailable: %s", exc)
+            return GenerationResult(
+                success=False,
+                error=str(exc),
+                meta=meta,
+            )
+        except ProviderError as exc:
+            logger.warning("Provider error: %s", exc)
+            return GenerationResult(
+                success=False,
+                error=str(exc),
+                provider=getattr(exc, "provider", None),
+                meta=CapabilityMetadata(
+                    capability="generation",
+                    provider=getattr(exc, "provider", None),
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 — facade must not leak
+            logger.exception("GenerationService.generate failed")
+            return GenerationResult(success=False, error=str(exc), meta=meta)
+
+    def _select_provider(self, request: GenerationRequest):
+        if request.provider:
+            named = self._registry.get(request.provider)
+            if named is None:
+                raise ProviderUnavailableError(
+                    self._default_capability, request.model
+                )
+            if not named.is_available():
+                raise ProviderUnavailableError(
+                    self._default_capability, request.model
+                )
+            return named
+        return self._router.select(self._default_capability, model=request.model)
+
+    @property
+    def registry(self) -> ProviderRegistry:
+        return self._registry


### PR DESCRIPTION
## Closes #69

- `yasinai.contracts.generation` — GenerationRequest / GenerationResult
- `yasinai.services.GenerationService` — facade over ProviderRouter
- Preferred provider + error result paths
- **221 passed**