### PR TITLE
fix: close production Docker and release-audit findings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Never send local credentials or Git metadata to the Docker daemon.
+.git
+.gitignore
+.env
+.env.*
+!.env.example
+
+# Local Python environments and caches
+.venv
+venv
+__pycache__
+.pytest_cache
+.mypy_cache
+.ruff_cache
+*.pyc
+*.pyo
+
+# Test/build artifacts
+.coverage
+coverage.xml
+htmlcov
+build
+dist
+*.egg-info
+
+# Local databases, logs, and runtime state
+*.db
+*.sqlite
+*.sqlite3
+*.log
+/data
+
+# Editor/OS metadata
+.vscode
+.idea
+.DS_Store

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,13 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: Build and Smoke Test
@@ -15,14 +22,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Workaround pyproject.toml setuptools flat-layout discovery
-        run: |
-          echo -e '\n[tool.setuptools]\npackages = ["yasinai", "yasinai.core", "yasinai.cli", "yasinai.deployment", "security_platform", "developer_platform", "knowledge_platform"]' >> pyproject.toml
-
       - name: Build Docker Image
-        run: |
-          docker build -t yasinai:latest .
+        run: docker build --pull -t yasinai:latest .
 
       - name: Run Smoke Test
-        run: |
-          docker run --rm yasinai:latest yasin status
+        run: docker run --rm yasinai:latest yasin status

--- a/PRODUCTION_RELEASE.md
+++ b/PRODUCTION_RELEASE.md
@@ -1,14 +1,14 @@
-# Yasin-AI v1.1.0 Production Release
+# Yasin-AI v1.1.1 Production Release
 
 Release target: `v1.1.1`
 
 ## Gate status
 
-- Security audit completed for both `v1.0.0` and the post-release maintenance `v1.1.0` branch.
+- Security audit completed for the v1.0.0 baseline and the subsequent maintenance line.
 - Release-candidate checklist completed.
-- CI test, coverage, dependency-audit, repository-security, and Docker smoke-test gates are defined and fully passing.
-- Packaging metadata reports version `1.1.1` in `pyproject.toml` and runtime reports `1.1.0` in `yasinai/__init__.py`.
-- Production deployment hardening is documented.
+- CI test, coverage, dependency-audit, repository-security, and Docker smoke-test gates are defined.
+- Packaging metadata and runtime metadata both report version `1.1.1`.
+- Production deployment hardening is documented and covered by repository-level readiness checks.
 - Known limitations are documented and intentionally accepted for this release.
 
 ## Deployment verification
@@ -23,13 +23,19 @@ python -m build
 
 Then build and exercise the production container/compose profile in the target environment and verify its healthcheck.
 
+```bash
+docker compose -f deploy/compose.production.yml up --build -d
+docker compose -f deploy/compose.production.yml ps
+docker compose -f deploy/compose.production.yml down
+```
+
 ## Rollback
 
 Keep the previous known-good image/package available. If a production deployment fails health checks or introduces a regression, redeploy the previous artifact and investigate from the release commit and CI artifacts.
 
 ## Scope
 
-This release establishes the current stable production maintenance baseline of the modular YasinAI platform (`v1.1.0`). Distributed HA storage, untrusted plugin sandboxing, and vendor-specific observability exporters remain future infrastructure work.
+This release is the current stable maintenance baseline of the modular YasinAI platform (`v1.1.1`). Distributed HA storage, untrusted plugin sandboxing, and vendor-specific observability exporters remain future infrastructure work.
 
 ---
 
@@ -41,17 +47,11 @@ Automated static gates live in `tests/test_production_profile.py`:
 |---|---|
 | Non-root image | Dockerfile `USER 10001` + `useradd` |
 | Image health | Dockerfile `HEALTHCHECK` → `yasin status` |
-| No secret bake-in | Dockerfile does not `COPY .env` |
+| No secret bake-in | `.dockerignore` excludes local environment files and credentials |
 | Production compose | `read_only`, `cap_drop: ALL`, `no-new-privileges`, limits, volume |
 | Secret hygiene | `.env.example` present; `.gitignore` blocks `.env` / keys |
 
-Operators still must run the production compose profile in the target environment
-before exposing traffic:
-
-```bash
-docker compose -f deploy/compose.production.yml up --build -d
-docker compose -f deploy/compose.production.yml ps
-```
+Operators still must run the production compose profile in the target environment before exposing traffic.
 
 ---
 
@@ -61,12 +61,11 @@ Automated readiness module: `tests/test_production_readiness.py`
 
 Validates:
 
-1. Version alignment (`pyproject.toml` / `yasinai.__version__` = 1.1.0)
+1. Version alignment (`pyproject.toml` / `yasinai.__version__` = `1.1.1`)
 2. Phase 3 modules (providers, generation, RAG)
 3. Phase 4 integration clients (Agent, Hub, CLI, Relay, Feed, Press)
 4. Phase 5 hardening artifacts (plugin trust policy, production profile tests)
-5. CI gates (`cov-fail-under`, pip-audit, security check)
+5. CI gates (`cov-fail-under`, `pip-audit`, security check)
 6. Public import smoke (contracts, services, integration, providers)
 
-`RELEASE_CHECKLIST.md` sections 12–14 record Phase 3–5 completion for the
-v1.1.0 maintenance line.
+`RELEASE_CHECKLIST.md` sections 12–14 record Phase 3–5 completion for the `v1.1.1` maintenance line.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - ENVIRONMENT=development
+      - YASINAI_ENVIRONMENT=development
     # Local hardening baseline (production profile is stricter)
     security_opt:
       - no-new-privileges:true

--- a/tests/test_production_readiness.py
+++ b/tests/test_production_readiness.py
@@ -57,7 +57,7 @@ def test_docker_workflow_does_not_mutate_pyproject():
 def test_development_compose_uses_supported_environment_prefix():
     compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
     assert "YASINAI_ENVIRONMENT=development" in compose
-    assert "ENVIRONMENT=development" not in compose
+    assert "\n      - ENVIRONMENT=development" not in compose
 
 
 def test_ci_coverage_gate_configured():

--- a/tests/test_production_readiness.py
+++ b/tests/test_production_readiness.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -12,8 +10,7 @@ def test_version_sources_aligned():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     assert 'version = "1.1.1"' in pyproject
     init = (ROOT / "yasinai" / "__init__.py").read_text(encoding="utf-8")
-    # version may be defined as string constant
-    assert "1.1.1" in init or "1.1" in init
+    assert "1.1.1" in init
 
 
 def test_phase3_capability_modules_present():
@@ -29,12 +26,8 @@ def test_phase3_capability_modules_present():
 def test_phase4_integration_clients_present():
     integ = ROOT / "yasinai" / "integration"
     for name in (
-        "agent_client.py",
-        "hub_client.py",
-        "cli_client.py",
-        "relay_client.py",
-        "feed_client.py",
-        "press_client.py",
+        "agent_client.py", "hub_client.py", "cli_client.py",
+        "relay_client.py", "feed_client.py", "press_client.py",
     ):
         assert (integ / name).is_file(), name
 
@@ -44,6 +37,27 @@ def test_phase5_hardening_artifacts_present():
     assert (ROOT / "tests" / "test_production_profile.py").is_file()
     assert (ROOT / "deploy" / "compose.production.yml").is_file()
     assert (ROOT / ".env.example").is_file()
+
+
+def test_docker_build_context_excludes_local_secrets():
+    dockerignore = (ROOT / ".dockerignore").read_text(encoding="utf-8")
+    assert ".env" in dockerignore
+    assert ".env.*" in dockerignore
+    assert "!.env.example" in dockerignore
+    assert ".git" in dockerignore
+    assert "credentials" in dockerignore
+
+
+def test_docker_workflow_does_not_mutate_pyproject():
+    workflow = (ROOT / ".github" / "workflows" / "docker-build.yml").read_text(encoding="utf-8")
+    assert "Workaround pyproject.toml" not in workflow
+    assert "docker build --pull" in workflow
+
+
+def test_development_compose_uses_supported_environment_prefix():
+    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    assert "YASINAI_ENVIRONMENT=development" in compose
+    assert "ENVIRONMENT=development" not in compose
 
 
 def test_ci_coverage_gate_configured():
@@ -56,41 +70,22 @@ def test_ci_coverage_gate_configured():
 def test_release_checklist_mentions_phase_gates():
     text = (ROOT / "RELEASE_CHECKLIST.md").read_text(encoding="utf-8")
     assert "v1.1.1" in text
-    # Phase 5.3 expands checklist — must mention providers or generation or RAG
-    assert any(
-        token in text
-        for token in ("Provider", "Generation", "RAG", "Integration", "Phase 5")
-    )
+    assert any(token in text for token in ("Provider", "Generation", "RAG", "Integration", "Phase 5"))
 
 
 def test_public_imports_smoke():
     from yasinai.contracts import GenerationRequest, RagRequest
     from yasinai.services import GenerationService, KnowledgeService, RagService
     from yasinai.integration import (
-        YasinAgentClient,
-        YasinCLIClient,
-        YasinFeedClient,
-        YasinHubClient,
-        YasinPressClient,
-        YasinRelayClient,
+        YasinAgentClient, YasinCLIClient, YasinFeedClient,
+        YasinHubClient, YasinPressClient, YasinRelayClient,
     )
-    from yasinai.providers import LocalProvider, build_default_registry
+    from yasinai.providers import LocalProvider, ProviderCapability, build_default_registry
 
     assert GenerationRequest and RagRequest
     assert GenerationService and KnowledgeService and RagService
-    assert all(
-        [
-            YasinAgentClient,
-            YasinHubClient,
-            YasinCLIClient,
-            YasinRelayClient,
-            YasinFeedClient,
-            YasinPressClient,
-        ]
-    )
+    assert all([YasinAgentClient, YasinHubClient, YasinCLIClient, YasinFeedClient, YasinPressClient, YasinRelayClient])
     reg = build_default_registry()
     assert reg.get("local") is not None or any(
-        p.info.name == "local" for p in reg.available_for_capability(
-            __import__("yasinai.providers", fromlist=["ProviderCapability"]).ProviderCapability.GENERATION
-        )
+        p.info.name == "local" for p in reg.available_for_capability(ProviderCapability.GENERATION)
     ) or LocalProvider().is_available()


### PR DESCRIPTION
## Audit Phase 1 — Critical/High production findings

This PR fixes confirmed issues found during the live repository audit of `Yasin-AI`.

### Findings fixed
- Docker release workflow was mutating `pyproject.toml` by appending a second `[tool.setuptools]` table, causing the production Docker build to fail with `TOMLDecodeError: Cannot overwrite a value`.
- Docker build context had no repository-level `.dockerignore`, so a developer-local `.env` or credential file could be sent to the Docker daemon and then copied by `COPY . .`.
- `docker-compose.yml` used `ENVIRONMENT=development`, but `Config` only consumes `YASINAI_*`, so the documented development environment override was ineffective.
- `PRODUCTION_RELEASE.md` contained stale/conflicting v1.1.0 claims after the v1.1.1 release.
- Production readiness tests did not protect the Docker build-context/workflow and compose configuration boundaries.

### Verification plan
GitHub Actions must validate:
- full pytest + coverage gate
- pip-audit + repository security scanner
- Docker build and `yasin status` smoke test

No secrets are included in this change.
