### PR TITLE
fix: persist production memory and vector stores on /data

### DIFF
--- a/deploy/compose.production.yml
+++ b/deploy/compose.production.yml
@@ -7,6 +7,9 @@ services:
     init: true
     env_file:
       - .env
+    environment:
+      YASINAI_MEMORY_PATH: /data/memory.db
+      YASINAI_VECTOR_PATH: /data/vectors.db
     volumes:
       - yasinai-data:/data
     security_opt:

--- a/tests/test_production_profile.py
+++ b/tests/test_production_profile.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -18,7 +16,6 @@ def test_dockerfile_runs_as_non_root():
 
 def test_dockerfile_does_not_copy_env_secrets_explicitly():
     text = (ROOT / "Dockerfile").read_text(encoding="utf-8")
-    # Must not COPY a live .env into the image
     assert "COPY .env" not in text
     assert "COPY *.pem" not in text
 
@@ -35,6 +32,13 @@ def test_production_compose_hardening():
     assert "yasinai-data" in text
     assert "pids_limit:" in text
     assert "mem_limit:" in text
+
+
+def test_production_persistence_paths_use_durable_volume():
+    text = (ROOT / "deploy" / "compose.production.yml").read_text(encoding="utf-8")
+    assert "YASINAI_MEMORY_PATH: /data/memory.db" in text
+    assert "YASINAI_VECTOR_PATH: /data/vectors.db" in text
+    assert "- yasinai-data:/data" in text
 
 
 def test_dev_compose_points_to_production_profile():


### PR DESCRIPTION
## Audit Phase 2 — production persistence finding

The production compose profile mounts `/data` as a durable volume, but the application defaults for both durable stores are under `~/.yasinai/`. The container's home directory is not the declared persistent volume, so a container replacement could lose long-term memory and vector data.

### Fix
- Bind `YASINAI_MEMORY_PATH` to `/data/memory.db`.
- Bind `YASINAI_VECTOR_PATH` to `/data/vectors.db`.
- Add a production-profile regression test that enforces the mapping.

### Verification
The existing CI gates plus the new production profile test must pass before merge.
