### PR TITLE
fix: reconcile release/README version drift to v1.1.2 (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [1.1.2] - 2026-08-15
+
+### Fixed
+- Release tag/README version drift: official release now includes Docker hardening (#89), persistent memory/vector storage (#90), and Python version contract fix (#91).
+- Installer default config no longer hardcodes `version = "1.0.0"`; reads package version dynamically.
+- README current-release claims aligned with `pyproject.toml` (**v1.1.2**).
+
 ## [1.1.1] - 2026-08-14
 
 ### Added

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 
 **Project:** YasinAI
 
-**Current Version:** 1.1.1
+**Current Version:** 1.1.2
 
 **Status:** Released / Post-release Maintenance
 
@@ -28,7 +28,7 @@ The architecture is divided into the following local capability platforms:
 We clearly delineate the platform's release lines to maintain strict ecosystem alignment:
 
 ### CURRENT RELEASE
-- **v1.1.1** — Current production maintenance release (Phases 2–5 complete). Unifies code metadata, dependencies auditing, and architecture documentation.
+- **v1.1.2** — Current production maintenance release (Phases 2–5 complete). Unifies code metadata, dependencies auditing, and architecture documentation.
 
 ### HISTORICAL RELEASES
 - **v1.0.0** — First official production release. Established core runtime, SDKs, memory retrieval, and hardened security.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ According to YASIN-DOCS ADR-001, Yasin-AI is the Canonical AI Capability Platfor
 - **YasinCLI**: Unified user-facing command surface. (The CLI in `yasinai/cli/` is a local diagnostic helper; the unified command interface is owned by YasinCLI).
 - **YasinRelay / YasinFeed / YasinPress**: Domain, content, and business pipelines.
 
-**Current release: v1.1.0**
+**Current release: v1.1.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
@@ -17,7 +17,7 @@ According to YASIN-DOCS ADR-001, Yasin-AI is the Canonical AI Capability Platfor
 
 Yasin-AI has completed its Phase 2.2 architecture reconciliation.
 
-- Reconciled version: **v1.1.0**
+- Reconciled version: **v1.1.2**
 - Security audit: completed
 - Release candidate verification: completed
 - Performance/reliability baseline: completed
@@ -113,8 +113,10 @@ Container deployments should additionally verify the production compose profile 
 
 ## Release history
 
-- **v1.1.0** — Current production release (aligned in Phase 2.2)
-- **v1.0.0** — Previous production release
+- **v1.1.2** — Current production release (includes Docker hardening + persistent storage + Python contract fixes)
+- **v1.1.1** — Phases 2–5 complete (contracts, providers, services, ecosystem integration)
+- **v1.1.0** — Maintenance baseline (aligned in Phase 2.2)
+- **v1.0.0** — First production release
 
 See the complete [release history](https://github.com/yusi20006-max/Yasin-AI/releases).
 
@@ -197,7 +199,7 @@ To maintain strict source-of-truth accuracy, all Yasin-AI capabilities are organ
 
 - **No HA/Distribution**: The default local SQLite storage is a single-node database. It is not designed for multi-node clusters or high availability.
 - **In-process Trust**: The execution environment does not sandbox third-party plugin code. Only run trusted plugins.
-- **Resolved Version Contradiction**: In Phase 2.2, version inconsistencies across code metadata, CLI outputs, and documentation have been formally resolved and unified to **v1.1.0** across the platform.
+- **Resolved Version Contradiction**: In Phase 2.2, version inconsistencies across code metadata, CLI outputs, and documentation were unified to **v1.1.0** in Phase 2.2 and remain synchronized through **v1.1.2**.
 
 ---
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,7 +1,7 @@
 # YasinAI Release Checklist
 
 Version:
-v1.1.1
+v1.1.2
 
 Status:
 Passed
@@ -258,7 +258,7 @@ Before every release:
 Release Status
 
 Version:
-1.1.1
+1.1.2
 
 Project:
 YasinAI

--- a/api_service/app.py
+++ b/api_service/app.py
@@ -16,7 +16,7 @@ Handler = Callable[[Mapping[str, Any]], Mapping[str, Any]]
 @dataclass
 class APIService:
     name: str = "yasinai"
-    version: str = "1.1.1"
+    version: str = "1.1.2"
     _routes: Optional[Dict[str, Handler]] = None
 
     def __post_init__(self) -> None:
@@ -56,5 +56,5 @@ class APIService:
         return path
 
 
-def create_service(name: str = "yasinai", version: str = "1.1.1") -> APIService:
+def create_service(name: str = "yasinai", version: str = "1.1.2") -> APIService:
     return APIService(name=name, version=version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yasinai"
-version = "1.1.1"
+version = "1.1.2"
 description = "YasinAI Modular AI Platform"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -66,7 +66,7 @@ def test_observability_context_defaults():
 def test_capability_metadata_defaults():
     meta = CapabilityMetadata(capability="memory")
     assert meta.contract_version == "v1"
-    assert meta.platform_version == "1.1.1"
+    assert meta.platform_version == "1.1.2"
     assert meta.provider is None
 
 

--- a/tests/test_production_readiness.py
+++ b/tests/test_production_readiness.py
@@ -8,9 +8,9 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_version_sources_aligned():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    assert 'version = "1.1.1"' in pyproject
+    assert 'version = "1.1.2"' in pyproject
     init = (ROOT / "yasinai" / "__init__.py").read_text(encoding="utf-8")
-    assert "1.1.1" in init
+    assert "1.1.2" in init
 
 
 def test_phase3_capability_modules_present():
@@ -69,7 +69,7 @@ def test_ci_coverage_gate_configured():
 
 def test_release_checklist_mentions_phase_gates():
     text = (ROOT / "RELEASE_CHECKLIST.md").read_text(encoding="utf-8")
-    assert "v1.1.1" in text
+    assert "v1.1.2" in text
     assert any(token in text for token in ("Provider", "Generation", "RAG", "Integration", "Phase 5"))
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -12,7 +12,7 @@ from yasinai.core.system import ServiceRegistry, SystemInfo
 def test_config_defaults():
     config = Config()
     assert config.get("app_name") == "YasinAI"
-    assert config.get("version") == "1.1.1"
+    assert config.get("version") == "1.1.2"
     assert config.get("debug") is False
     assert config.get("modules") == []
 

--- a/yasinai/__init__.py
+++ b/yasinai/__init__.py
@@ -1,3 +1,3 @@
 # YasinAI Package
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/yasinai/cli/main.py
+++ b/yasinai/cli/main.py
@@ -380,7 +380,7 @@ def create_parser() -> argparse.ArgumentParser:
 
     package_build_parser = package_subparsers.add_parser("build", help="Build deployment artifacts", parents=[parent_parser])
     package_build_parser.add_argument("--output", default="dist/", help="Output directory")
-    package_build_parser.add_argument("--version", default="1.1.1", help="Target package version")
+    package_build_parser.add_argument("--version", default="1.1.2", help="Target package version")
     package_build_parser.set_defaults(func=handle_package_build)
 
     # 6. 'serve' command

--- a/yasinai/contracts/base.py
+++ b/yasinai/contracts/base.py
@@ -52,5 +52,5 @@ class CapabilityMetadata:
 
     capability: str
     contract_version: str = "v1"
-    platform_version: str = "1.1.1"
+    platform_version: str = "1.1.2"
     provider: Optional[str] = None

--- a/yasinai/core/config.py
+++ b/yasinai/core/config.py
@@ -19,7 +19,7 @@ class Config:
         """
         self._config: Dict[str, Any] = {
             "app_name": "YasinAI",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "environment": "production",
             "debug": False,
             "modules": []

--- a/yasinai/core/runtime.py
+++ b/yasinai/core/runtime.py
@@ -25,7 +25,7 @@ class Runtime:
         self.services: ServiceRegistry = ServiceRegistry()
         self.system_info: SystemInfo = SystemInfo(
             app_name=self.config.get("app_name", "YasinAI"),
-            version=self.config.get("version", "1.1.1"),
+            version=self.config.get("version", "1.1.2"),
             status="inactive",
         )
         self.bootstrap_loader: Bootstrap = Bootstrap(self)

--- a/yasinai/core/system.py
+++ b/yasinai/core/system.py
@@ -11,7 +11,7 @@ class SystemInfo:
     Provides key information about the running YasinAI system and its environment.
     """
 
-    def __init__(self, app_name: str = "YasinAI", version: str = "1.1.1", status: str = "unknown") -> None:
+    def __init__(self, app_name: str = "YasinAI", version: str = "1.1.2", status: str = "unknown") -> None:
         self.app_name: str = app_name
         self.version: str = version
         self.status: str = status

--- a/yasinai/deployment/installer.py
+++ b/yasinai/deployment/installer.py
@@ -85,9 +85,17 @@ class Installer:
         config_path = os.path.join(self.target_directory, "config", "config.json")
         config_created = False
         if not os.path.exists(config_path):
+            try:
+                from yasinai import __version__ as _pkg_version
+            except Exception:
+                try:
+                    from importlib.metadata import version as _meta_version
+                    _pkg_version = _meta_version("yasinai")
+                except Exception:
+                    _pkg_version = "0.0.0"
             default_config = {
                 "app_name": "YasinAI",
-                "version": "1.0.0",
+                "version": _pkg_version,
                 "debug": False,
                 "modules": []
             }


### PR DESCRIPTION
## Closes #92

### Changes
- **README**: Current release → **v1.1.2**; release history + Phase 2.2 note updated
- **Installer**: default `config.json` version read dynamically from package metadata (no hardcoded `1.0.0`)
- **Authoritative version** bumped to **1.1.2** (`pyproject.toml`, runtime defaults, contracts metadata)
- **CHANGELOG**: entry for 1.1.2 describing inclusion of #89/#90/#91

### Tag decision
**New tag `v1.1.2` will be cut at `main` HEAD after this PR merges** (additive only; `v1.1.1` left immutable). Rationale: `v1.1.1` predates production Docker hardening (#89), persistent stores (#90), and Python contract fix (#91); rewriting that tag is disallowed.

### Pre-PR checklist
- [x] README matches pyproject version (1.1.2)
- [x] CHANGELOG entry for new tag
- [x] Installer no longer hardcodes 1.0.0
- [ ] Tag created after merge at main HEAD

### Tests
268 passed locally