### PR TITLE
fix(providers): fail explicitly on unmatched model in ProviderRouter (#93)

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -224,12 +224,22 @@ def test_router_selects_by_model_hint():
     assert provider.info.name == "provider-b"
 
 
-def test_router_falls_back_when_no_model_match():
+def test_router_raises_on_unknown_model_by_default():
     reg = ProviderRegistry()
     reg.register(StubGenerationProvider(name="only-provider", models=["model-x"]))
     router = ProviderRouter(reg)
-    # unknown-model has no exact match — falls back to first available
-    provider = router.select(ProviderCapability.GENERATION, model="unknown-model")
+    with pytest.raises(ProviderUnavailableError) as exc_info:
+        router.select(ProviderCapability.GENERATION, model="unknown-model")
+    assert exc_info.value.model == "unknown-model"
+
+
+def test_router_falls_back_when_allow_fallback_true():
+    reg = ProviderRegistry()
+    reg.register(StubGenerationProvider(name="only-provider", models=["model-x"]))
+    router = ProviderRouter(reg)
+    provider = router.select(
+        ProviderCapability.GENERATION, model="unknown-model", allow_fallback=True
+    )
     assert provider.info.name == "only-provider"
 
 

--- a/yasinai/providers/router.py
+++ b/yasinai/providers/router.py
@@ -1,13 +1,12 @@
 """
 Provider Router — selects the best available provider for a capability.
 
-Routing policy (Phase 2.6):
-  1. If model hint is given, prefer the provider whose model_ids contain it.
-  2. Otherwise, return the first available provider for the capability.
-  3. If none available, raise ProviderUnavailableError.
-
-Phase 3 will extend this with priority weights, cost routing, and
-fallback chains defined in configuration.
+Routing policy:
+  1. If model hint is given, select the provider whose model_ids contain it.
+  2. If model is given and no provider lists it: raise ProviderUnavailableError
+     unless allow_fallback=True (opt-in best-effort).
+  3. If no model hint, return the first available provider for the capability.
+  4. If none available, raise ProviderUnavailableError.
 """
 from __future__ import annotations
 
@@ -48,14 +47,31 @@ class ProviderRouter:
         self,
         capability: ProviderCapability,
         model: Optional[str] = None,
+        *,
+        allow_fallback: bool = False,
     ) -> ProviderBase:
+        """
+        Select an available provider for ``capability``.
+
+        Args:
+            capability: Required provider capability.
+            model: Optional model id hint. When set, only a provider that lists
+                this id in ``info.model_ids`` is selected unless
+                ``allow_fallback`` is True.
+            allow_fallback: If True and ``model`` has no exact match, use the
+                first available provider for the capability (best-effort).
+                Default False — raise ``ProviderUnavailableError`` on mismatch.
+
+        Raises:
+            ProviderUnavailableError: No available provider, or model mismatch
+                without ``allow_fallback``.
+        """
         candidates = self._registry.available_for_capability(capability)
 
         if not candidates:
             raise ProviderUnavailableError(capability, model)
 
         if model:
-            # Prefer a provider that explicitly lists this model_id
             for provider in candidates:
                 if model in provider.info.model_ids:
                     logger.debug(
@@ -63,9 +79,14 @@ class ProviderRouter:
                         provider.info.name, capability.value, model,
                     )
                     return provider
-            # Fall through: use first available if no exact model match
+            if not allow_fallback:
+                logger.debug(
+                    "Router: no provider lists model '%s' for capability=%s",
+                    model, capability.value,
+                )
+                raise ProviderUnavailableError(capability, model)
             logger.debug(
-                "Router: no exact model match for '%s'; using first available provider '%s'",
+                "Router: no exact model match for '%s'; fallback to first available '%s'",
                 model, candidates[0].info.name,
             )
 


### PR DESCRIPTION
## Closes #93

### Call sites audited
| Site | Change |
|------|--------|
| `GenerationService._select_provider` → `router.select(...)` | **unchanged** (default fail — callers requesting a model must not get a silent substitute) |
| tests only | updated |

No other production `router.select()` call sites.

### Behavior
- Default: unmatched `model` → `ProviderUnavailableError`
- `allow_fallback=True`: previous best-effort behavior

### Tests
- `test_router_raises_on_unknown_model_by_default`
- `test_router_falls_back_when_allow_fallback_true`
- 269 passed locally