### PR TITLE
fix(providers): redact raw HTTP bodies from provider exceptions (#94)

### DIFF
--- a/tests/test_concrete_providers.py
+++ b/tests/test_concrete_providers.py
@@ -108,8 +108,37 @@ def test_openai_bad_response_shape():
         return {"choices": []}
 
     p = OpenAIProvider(api_key="sk-test", transport=transport)
-    with pytest.raises(ProviderError, match="Unexpected response"):
+    with pytest.raises(ProviderError, match="unexpected response format") as ei:
         p.generate(GenerationRequest(prompt="x"))
+    # must not leak payload dump
+    assert "choices" not in str(ei.value)
+
+
+def test_openai_http_error_message_redacted(monkeypatch):
+    import urllib.error
+    from yasinai.providers import openai_provider as mod
+
+    class FakeHTTPError(urllib.error.HTTPError):
+        def __init__(self):
+            pass
+        code = 400
+        def read(self):
+            return b'{"error":{"message":"secret-provider-detail","type":"invalid_request"}}'
+
+    def boom(url, headers, body):
+        raise FakeHTTPError()
+
+    # Exercise default transport path by patching urlopen
+    def fake_urlopen(req, timeout=60):
+        raise FakeHTTPError()
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    with pytest.raises(ProviderError) as ei:
+        mod._default_http_transport("https://api.openai.com/v1/chat/completions", {}, {})
+    msg = str(ei.value)
+    assert "HTTP 400" in msg or "400" in msg
+    assert "secret-provider-detail" not in msg
+    assert ei.value.retryable is False
 
 
 # ---------------------------------------------------------------------------

--- a/yasinai/providers/anthropic_provider.py
+++ b/yasinai/providers/anthropic_provider.py
@@ -3,10 +3,15 @@ AnthropicProvider — Anthropic Messages API adapter.
 
 Credentials: ANTHROPIC_API_KEY only (never hardcoded).
 SDK libraries are not required at import time; HTTP transport is injectable.
+
+Exception messages must never contain raw provider HTTP bodies or full
+response payloads. Log raw details at logger.error/debug only; raise a
+safe generic ProviderError message for callers / GenerationResult.error.
 """
 from __future__ import annotations
 
 import json
+import logging
 import os
 import urllib.error
 import urllib.request
@@ -23,6 +28,8 @@ from yasinai.providers.base import (
 
 HttpTransport = Callable[[str, Dict[str, str], Dict[str, Any]], Dict[str, Any]]
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_BASE_URL = "https://api.anthropic.com"
 DEFAULT_MODEL = "claude-3-5-haiku-latest"
 ANTHROPIC_VERSION = "2023-06-01"
@@ -38,11 +45,23 @@ def _default_http_transport(
             return json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")
+        logger.error(
+            "Anthropic HTTP %s error (raw body withheld from exception): %s",
+            exc.code,
+            detail,
+        )
         raise ProviderError(
-            "anthropic", f"HTTP {exc.code}: {detail}", retryable=exc.code >= 500
+            "anthropic",
+            f"Anthropic request failed with HTTP {exc.code}",
+            retryable=exc.code >= 500,
         ) from exc
     except urllib.error.URLError as exc:
-        raise ProviderError("anthropic", f"Network error: {exc}", retryable=True) from exc
+        logger.error("Anthropic network error: %s", exc)
+        raise ProviderError(
+            "anthropic",
+            "Anthropic network error",
+            retryable=True,
+        ) from exc
 
 
 class AnthropicProvider(ProviderBase):
@@ -118,7 +137,12 @@ class AnthropicProvider(ProviderBase):
         except ProviderError:
             raise
         except Exception as exc:  # noqa: BLE001
-            raise ProviderError("anthropic", str(exc), retryable=True) from exc
+            logger.error("Anthropic transport error: %s", exc)
+            raise ProviderError(
+                "anthropic",
+                "Anthropic request failed",
+                retryable=True,
+            ) from exc
 
         try:
             blocks = payload.get("content") or []
@@ -129,9 +153,13 @@ class AnthropicProvider(ProviderBase):
             usage = payload.get("usage") or {}
             finish = payload.get("stop_reason")
         except (TypeError, AttributeError) as exc:
+            logger.error(
+                "Anthropic unexpected response shape (payload withheld from exception): %r",
+                payload,
+            )
             raise ProviderError(
                 "anthropic",
-                f"Unexpected response shape: {payload!r}",
+                "unexpected response format from provider",
                 retryable=False,
             ) from exc
 

--- a/yasinai/providers/openai_provider.py
+++ b/yasinai/providers/openai_provider.py
@@ -4,14 +4,21 @@ OpenAIProvider — OpenAI Chat Completions adapter.
 Credentials: OPENAI_API_KEY only (never hardcoded).
 SDK libraries are imported inside call methods, not at module level.
 HTTP transport is injectable for unit tests (no live API required).
+
+Exception messages must never contain raw provider HTTP bodies or full
+response payloads. Log raw details at logger.error/debug only; raise a
+safe generic ProviderError message for callers / GenerationResult.error.
 """
 from __future__ import annotations
 
 import json
+import logging
 import os
 import urllib.error
 import urllib.request
 from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
 
 from yasinai.providers.base import (
     GenerationRequest,
@@ -39,9 +46,23 @@ def _default_http_transport(
             return json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")
-        raise ProviderError("openai", f"HTTP {exc.code}: {detail}", retryable=exc.code >= 500) from exc
+        logger.error(
+            "OpenAI HTTP %s error (raw body withheld from exception): %s",
+            exc.code,
+            detail,
+        )
+        raise ProviderError(
+            "openai",
+            f"OpenAI request failed with HTTP {exc.code}",
+            retryable=exc.code >= 500,
+        ) from exc
     except urllib.error.URLError as exc:
-        raise ProviderError("openai", f"Network error: {exc}", retryable=True) from exc
+        logger.error("OpenAI network error: %s", exc)
+        raise ProviderError(
+            "openai",
+            "OpenAI network error",
+            retryable=True,
+        ) from exc
 
 
 class OpenAIProvider(ProviderBase):
@@ -122,7 +143,12 @@ class OpenAIProvider(ProviderBase):
         except ProviderError:
             raise
         except Exception as exc:  # noqa: BLE001 — boundary: never leak transport errors
-            raise ProviderError("openai", str(exc), retryable=True) from exc
+            logger.error("OpenAI transport error: %s", exc)
+            raise ProviderError(
+                "openai",
+                "OpenAI request failed",
+                retryable=True,
+            ) from exc
 
         try:
             choice = payload["choices"][0]
@@ -130,9 +156,13 @@ class OpenAIProvider(ProviderBase):
             usage = payload.get("usage") or {}
             finish = choice.get("finish_reason")
         except (KeyError, IndexError, TypeError) as exc:
+            logger.error(
+                "OpenAI unexpected response shape (payload withheld from exception): %r",
+                payload,
+            )
             raise ProviderError(
                 "openai",
-                f"Unexpected response shape: {payload!r}",
+                "unexpected response format from provider",
                 retryable=False,
             ) from exc
 


### PR DESCRIPTION
## Closes #94

- Safe external messages: `OpenAI request failed with HTTP {code}` / `unexpected response format from provider`
- Raw body only in `logger.error`
- 270 passed locally

Before: `HTTP 400: {"error":{"message":"secret..."}}`
After: `OpenAI request failed with HTTP 400`