### PR TITLE
fix(deployment): guard DockerManager against clobbering production files (#95)

### DIFF
--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -71,13 +71,31 @@ def test_docker_manager_generation(tmp_path):
     assert res["dockerfile_created"] is True
     assert res["compose_created"] is True
 
-    assert os.path.exists(os.path.join(tmp_path, "Dockerfile"))
-    assert os.path.exists(os.path.join(tmp_path, "docker-compose.yml"))
+    dockerfile = (tmp_path / "Dockerfile").read_text(encoding="utf-8")
+    compose = (tmp_path / "docker-compose.yml").read_text(encoding="utf-8")
+    assert "USER 10001:10001" in dockerfile
+    assert "HEALTHCHECK" in dockerfile
+    assert "no-new-privileges:true" in compose
+    assert "cap_drop:" in compose
+    assert "YASINAI_ENVIRONMENT" in compose
+    assert "ENVIRONMENT=production" not in compose
 
     # Shouldn't recreate files if they exist and overwrite is False
     res_second = manager.generate_docker_files(overwrite=False)
     assert res_second["dockerfile_created"] is False
     assert res_second["compose_created"] is False
+
+    # overwrite=True alone must not clobber existing files
+    res_unsafe = manager.generate_docker_files(overwrite=True)
+    assert res_unsafe["dockerfile_created"] is False
+    assert res_unsafe["compose_created"] is False
+
+    # Explicit dual confirmation required to replace existing files
+    res_force = manager.generate_docker_files(
+        overwrite=True, confirm_overwrite_production=True
+    )
+    assert res_force["dockerfile_created"] is True
+    assert res_force["compose_created"] is True
 
 
 def test_docker_manager_status(tmp_path):

--- a/yasinai/deployment/docker_manager.py
+++ b/yasinai/deployment/docker_manager.py
@@ -3,6 +3,8 @@ Docker Manager for YasinAI Deployment System.
 Handles Dockerfile/docker-compose generation, status check, and deployment configuration.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import shutil
@@ -10,6 +12,67 @@ import subprocess
 from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
+
+# Scaffold templates aligned with production hardening (non-root, healthcheck).
+# Real production deploy profile remains deploy/compose.production.yml — never clobber
+# an existing repo-root Dockerfile without confirm_overwrite_production=True.
+_HARDENED_DOCKERFILE = """FROM python:3.12-slim
+
+WORKDIR /app
+
+# Secrets must never be baked into the image.
+COPY pyproject.toml README.md LICENSE ./
+COPY yasinai ./yasinai
+COPY security_platform ./security_platform
+COPY developer_platform ./developer_platform
+COPY knowledge_platform ./knowledge_platform
+COPY api_service ./api_service
+COPY observability ./observability
+
+RUN python -m pip install --no-cache-dir --upgrade pip \\
+    && python -m pip install --no-cache-dir . \\
+    && useradd --system --uid 10001 --no-create-home yasinai \\
+    && chown -R yasinai:yasinai /app
+
+COPY --chown=yasinai:yasinai . .
+
+USER 10001:10001
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \\
+  CMD yasin status || exit 1
+
+CMD ["yasin", "status"]
+"""
+
+_HARDENED_COMPOSE = """version: "3.8"
+
+# Scaffolded compose. For production hardening prefer:
+#   docker compose -f deploy/compose.production.yml up
+
+services:
+  yasinai:
+    build: .
+    container_name: yasinai-container
+    ports:
+      - "8000:8000"
+    environment:
+      - YASINAI_ENVIRONMENT=development
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: false
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=64m
+    healthcheck:
+      test: ["CMD", "yasin", "status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+"""
 
 
 class DockerManager:
@@ -21,26 +84,25 @@ class DockerManager:
         self.root_directory: str = root_directory
 
     def check_docker_available(self) -> bool:
-        """
-        Check if the docker command-line tool is installed.
-        """
+        """Check if the docker command-line tool is installed."""
         logger.debug("Checking if Docker command-line tool is available...")
         available = shutil.which("docker") is not None
         logger.debug(f"Docker availability: {available}")
         return available
 
     def check_docker_compose_available(self) -> bool:
-        """
-        Check if docker-compose or 'docker compose' is available.
-        """
+        """Check if docker-compose or 'docker compose' is available."""
         logger.debug("Checking if Docker Compose is available...")
         if shutil.which("docker-compose") is not None:
             logger.debug("Found 'docker-compose' binary in path.")
             return True
-        # Try running 'docker compose version'
         if self.check_docker_available():
             try:
-                res = subprocess.run(["docker", "compose", "version"], capture_output=True, text=True)
+                res = subprocess.run(
+                    ["docker", "compose", "version"],
+                    capture_output=True,
+                    text=True,
+                )
                 success = res.returncode == 0
                 logger.debug(f"'docker compose' verification exit code: {res.returncode}")
                 return success
@@ -50,72 +112,94 @@ class DockerManager:
         logger.debug("Docker Compose is not available.")
         return False
 
-    def generate_docker_files(self, overwrite: bool = False) -> Dict[str, bool]:
+    def generate_docker_files(
+        self,
+        overwrite: bool = False,
+        *,
+        confirm_overwrite_production: bool = False,
+    ) -> Dict[str, bool]:
         """
-        Ensure Dockerfile and docker-compose.yml exist at the repository root.
+        Ensure Dockerfile and docker-compose.yml exist under ``root_directory``.
+
+        Existing files are **never** overwritten unless both ``overwrite=True``
+        **and** ``confirm_overwrite_production=True``. A single boolean must
+        not be able to silently replace hardened production Docker files.
+
+        Generated templates follow current hardening conventions (non-root
+        USER 10001, HEALTHCHECK, cap_drop / no-new-privileges in compose,
+        YASINAI_* env prefix).
         """
-        logger.info(f"Generating Docker files in target directory '{self.root_directory}' (overwrite={overwrite})...")
+        logger.info(
+            "Generating Docker files in '%s' (overwrite=%s, confirm_overwrite_production=%s)",
+            self.root_directory,
+            overwrite,
+            confirm_overwrite_production,
+        )
         dockerfile_path = os.path.join(self.root_directory, "Dockerfile")
         compose_path = os.path.join(self.root_directory, "docker-compose.yml")
 
-        dockerfile_content = (
-            "FROM python:3.12-slim\n\n"
-            "WORKDIR /app\n\n"
-            "COPY pyproject.toml README.md ./\n"
-            "RUN pip install --no-cache-dir poetry && poetry config virtualenvs.create false\n\n"
-            "COPY . .\n"
-            "RUN poetry install --no-root && pip install .\n\n"
-            "EXPOSE 8000\n\n"
-            'CMD ["yasin", "status"]\n'
+        dockerfile_created = self._write_if_allowed(
+            dockerfile_path,
+            _HARDENED_DOCKERFILE,
+            overwrite=overwrite,
+            confirm_overwrite_production=confirm_overwrite_production,
+            label="Dockerfile",
         )
-
-        compose_content = (
-            "version: '3.8'\n\n"
-            "services:\n"
-            "  yasinai:\n"
-            "    build: .\n"
-            "    container_name: yasinai-container\n"
-            "    ports:\n"
-            "      - \"8000:8000\"\n"
-            "    environment:\n"
-            "      - ENVIRONMENT=production\n"
+        compose_created = self._write_if_allowed(
+            compose_path,
+            _HARDENED_COMPOSE,
+            overwrite=overwrite,
+            confirm_overwrite_production=confirm_overwrite_production,
+            label="docker-compose.yml",
         )
-
-        dockerfile_created = False
-        try:
-            if not os.path.exists(dockerfile_path) or overwrite:
-                with open(dockerfile_path, "w", encoding="utf-8") as f:
-                    f.write(dockerfile_content)
-                dockerfile_created = True
-                logger.info(f"Created Dockerfile at: {dockerfile_path}")
-        except IOError as e:
-            logger.error(f"Failed to write Dockerfile: {e}", exc_info=True)
-
-        compose_created = False
-        try:
-            if not os.path.exists(compose_path) or overwrite:
-                with open(compose_path, "w", encoding="utf-8") as f:
-                    f.write(compose_content)
-                compose_created = True
-                logger.info(f"Created docker-compose.yml at: {compose_path}")
-        except IOError as e:
-            logger.error(f"Failed to write docker-compose.yml: {e}", exc_info=True)
 
         return {
             "dockerfile_created": dockerfile_created,
-            "compose_created": compose_created
+            "compose_created": compose_created,
         }
 
+    def _write_if_allowed(
+        self,
+        path: str,
+        content: str,
+        *,
+        overwrite: bool,
+        confirm_overwrite_production: bool,
+        label: str,
+    ) -> bool:
+        exists = os.path.exists(path)
+        if exists and not overwrite:
+            logger.debug("Skipping existing %s (overwrite=False)", label)
+            return False
+        if exists and overwrite and not confirm_overwrite_production:
+            logger.warning(
+                "Refusing to overwrite existing %s at %s without "
+                "confirm_overwrite_production=True (protects production hardening)",
+                label,
+                path,
+            )
+            return False
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(content)
+            logger.info("Wrote %s at: %s", label, path)
+            return True
+        except IOError as e:
+            logger.error("Failed to write %s: %s", label, e, exc_info=True)
+            return False
+
     def get_docker_status(self) -> Dict[str, Any]:
-        """
-        Get status of docker tools and files.
-        """
+        """Get status of docker tools and files."""
         logger.debug("Retrieving Docker deployment status...")
         status = {
             "docker_available": self.check_docker_available(),
             "docker_compose_available": self.check_docker_compose_available(),
-            "dockerfile_exists": os.path.exists(os.path.join(self.root_directory, "Dockerfile")),
-            "docker_compose_exists": os.path.exists(os.path.join(self.root_directory, "docker-compose.yml"))
+            "dockerfile_exists": os.path.exists(
+                os.path.join(self.root_directory, "Dockerfile")
+            ),
+            "docker_compose_exists": os.path.exists(
+                os.path.join(self.root_directory, "docker-compose.yml")
+            ),
         }
         logger.debug(f"Docker status results: {status}")
         return status


### PR DESCRIPTION
## Closes #95

### Option chosen: (b) keep + harden
Generator still useful for empty target dirs; templates now match production conventions.

### Safety
- Existing files require `overwrite=True` **and** `confirm_overwrite_production=True`
- `overwrite=True` alone no longer overwrites

### Call sites
- Only `tests/test_deployment.py` (updated)
- No CLI/docs workflow invokes this for production paths

### Production files
Dockerfile / docker-compose.yml / deploy/* **unchanged** in this PR.

### Tests
270 passed locally