### PR TITLE
fix: APIService converts unhandled exceptions into standard error responses

### DIFF
--- a/api_service/app.py
+++ b/api_service/app.py
@@ -5,11 +5,14 @@ HTTP/CLI adapters can depend on this layer without coupling the core to a web fr
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Mapping, Optional
 
 from .errors import APIError, ValidationError
 from .models import HealthResponse, ServiceResponse
+
+logger = logging.getLogger(__name__)
 
 Handler = Callable[[Mapping[str, Any]], Mapping[str, Any]]
 
@@ -46,6 +49,14 @@ class APIService:
             result = dict(handler(payload or {}))
         except APIError as exc:
             return ServiceResponse(exc.status_code, {"error": str(exc)})
+        except Exception:
+            # Any exception the handler doesn't raise as an APIError is a bug
+            # in the handler, not a client error. Log full details internally
+            # for debugging; never leak exception text or a traceback into
+            # the response body — same "don't expose internals" principle
+            # applied to provider error handling elsewhere in this codebase.
+            logger.error("Unhandled exception in handler for %s", key, exc_info=True)
+            return ServiceResponse(500, {"error": "internal server error"})
         return ServiceResponse(200, result)
 
     @staticmethod

--- a/tests/test_api_service.py
+++ b/tests/test_api_service.py
@@ -28,3 +28,36 @@ def test_duplicate_route_is_rejected() -> None:
     service.add_route("GET", "/x", lambda _: {})
     with pytest.raises(ValidationError):
         service.add_route("get", "/x/", lambda _: {})
+
+
+def test_unhandled_exception_returns_generic_500() -> None:
+    service = create_service()
+    service.add_route("GET", "/boom", lambda _: (_ for _ in ()).throw(RuntimeError("db exploded")))
+    response = service.dispatch("GET", "/boom")
+    assert response.status == 500
+    assert response.data == {"error": "internal server error"}
+    # The real exception message must never leak into the response body.
+    assert "db exploded" not in str(response.data)
+
+
+def test_unhandled_exception_response_shape_matches_api_error_shape() -> None:
+    service = create_service()
+    service.add_route("GET", "/api-error", lambda _: (_ for _ in ()).throw(ValidationError("bad input")))
+    service.add_route("GET", "/bug", lambda _: (_ for _ in ()).throw(KeyError("missing")))
+
+    api_error_response = service.dispatch("GET", "/api-error")
+    unhandled_response = service.dispatch("GET", "/bug")
+
+    assert set(api_error_response.data.keys()) == set(unhandled_response.data.keys()) == {"error"}
+
+
+def test_unhandled_exception_is_logged_with_traceback(caplog) -> None:
+    import logging
+
+    service = create_service()
+    service.add_route("GET", "/boom", lambda _: (_ for _ in ()).throw(RuntimeError("db exploded")))
+    with caplog.at_level(logging.ERROR, logger="api_service.app"):
+        service.dispatch("GET", "/boom")
+
+    assert "Unhandled exception" in caplog.text
+    assert "db exploded" in caplog.text


### PR DESCRIPTION
Fixes #98.

## Changes
`api_service/app.py::dispatch()` only caught `APIError`. Any handler bug raising a plain exception (`RuntimeError`, `KeyError`, etc.) propagated uncaught instead of producing a standard response — contradicting the "centralized error handling" claim in the README.

- Added a catch-all `except Exception` below the existing `APIError` handler.
- Logs the full exception with traceback internally via `logger.error(..., exc_info=True)`.
- Returns `ServiceResponse(500, {"error": "internal server error"})` — same shape (`{"error": ...}`) as the existing `APIError` response path, with no exception text or traceback in the response body.

## Constraints respected
- Existing `APIError` handling behavior is completely unchanged (still first in the except chain).
- No exception details, stack traces, or internal state leak into the response body — only into internal logs.

## Tests
3 new tests in `tests/test_api_service.py`:
- `test_unhandled_exception_returns_generic_500` — confirms 500 + generic message, and that the real exception text never appears in the response.
- `test_unhandled_exception_response_shape_matches_api_error_shape` — confirms both paths return the same `{"error"}` key shape.
- `test_unhandled_exception_is_logged_with_traceback` — confirms full details are captured internally via logging.

## Verification
Full suite: 281 passed (up from 278 baseline + 3 new).
