### PR TITLE
fix: PackageBuilder produces a real deployment artifact

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -265,9 +265,10 @@ def test_handle_security_check_json(capsys):
 
 
 # Test 'package build' handler
-def test_handle_package_build_text(capsys):
+def test_handle_package_build_text(capsys, tmp_path):
+    output_dir = str(tmp_path / "custom_dist") + "/"
     args = argparse.Namespace(
-        output="custom_dist/",
+        output=output_dir,
         version="2.1.0",
         json=False
     )
@@ -275,13 +276,14 @@ def test_handle_package_build_text(capsys):
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "Building YasinAI deployment package v2.1.0..." in captured.out
-    assert "Target directory: custom_dist/" in captured.out
-    assert "SUCCESS: Created build artifact: custom_dist/yasinai-pkg-2.1.0.tar.gz" in captured.out
+    assert f"Target directory: {output_dir}" in captured.out
+    assert f"SUCCESS: Created build artifact: {output_dir}yasinai-pkg-2.1.0.tar.gz" in captured.out
 
 
-def test_handle_package_build_json(capsys):
+def test_handle_package_build_json(capsys, tmp_path):
+    output_dir = str(tmp_path / "custom_dist") + "/"
     args = argparse.Namespace(
-        output="custom_dist/",
+        output=output_dir,
         version="2.1.0",
         json=True
     )
@@ -291,7 +293,7 @@ def test_handle_package_build_json(capsys):
     data = json.loads(captured.out)
     assert data["success"] is True
     assert data["package_name"] == "yasinai-pkg-2.1.0.tar.gz"
-    assert data["output_directory"] == "custom_dist/"
+    assert data["output_directory"] == output_dir
 
 
 # Test main CLI dispatching and error/help handling
@@ -352,9 +354,10 @@ def test_main_security_check(capsys):
     assert "YasinAI Security Platform - Audit Check" in captured.out
 
 
-def test_main_package_build(capsys):
+def test_main_package_build(capsys, tmp_path):
+    output_dir = str(tmp_path / "build") + "/"
     with pytest.raises(SystemExit) as exc_info:
-        main(["package", "build", "--output", "build/"])
+        main(["package", "build", "--output", output_dir])
     assert exc_info.value.code == 0
     captured = capsys.readouterr()
     assert "Building YasinAI deployment package" in captured.out

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -152,14 +152,17 @@ def test_health_check_run_all():
 
 
 # 4. Tests for PackageBuilder
-def test_package_builder_build():
+def test_package_builder_build(tmp_path):
     builder = PackageBuilder()
-    res = builder.build_package(name="yasinai", version="1.0.0", output_directory="dist/")
+    dist_dir = str(tmp_path / "dist") + "/"
+    temp_dir = str(tmp_path / "temp") + "/"
+
+    res = builder.build_package(name="yasinai", version="1.0.0", output_directory=dist_dir)
     assert res["success"] is True
     assert res["package_name"] == "yasinai-pkg-1.0.0.tar.gz"
     assert "yasinai/core/" in res["files_included"]
 
-    res_other = builder.build_package(name="custom-plugin", version="2.5", output_directory="temp/")
+    res_other = builder.build_package(name="custom-plugin", version="2.5", output_directory=temp_dir)
     assert res_other["package_name"] == "custom-plugin-v2.5.tar.gz"
 
 

--- a/tests/test_developer_platform.py
+++ b/tests/test_developer_platform.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from developer_platform.agent import Agent, AgentSDK
 from developer_platform.plugin import Plugin, PluginSDK
@@ -298,17 +300,81 @@ def test_profiler():
     assert prof.get_profile_report() == {"status": "no profiles recorded"}
 
 
-def test_package_builder():
+def test_package_builder(tmp_path):
     builder = PackageBuilder()
+    build_dir = str(tmp_path / "build") + "/"
+    dist_dir = str(tmp_path / "dist") + "/"
 
-    res = builder.build_package(name="yasinai", version="1.5.0", output_directory="build/")
+    res = builder.build_package(name="yasinai", version="1.5.0", output_directory=build_dir)
     assert res["success"] is True
     assert res["package_name"] == "yasinai-pkg-1.5.0.tar.gz"
-    assert res["output_directory"] == "build/"
+    assert res["output_directory"] == build_dir
     assert "yasinai/core/" in res["files_included"]
 
-    res_plugin = builder.build_package(name="my-plugin", version="2.0", output_directory="dist/")
+    res_plugin = builder.build_package(name="my-plugin", version="2.0", output_directory=dist_dir)
     assert res_plugin["package_name"] == "my-plugin-v2.0.tar.gz"
+
+
+def test_package_builder_creates_real_archive_on_disk(tmp_path):
+    import tarfile
+
+    # Set up a minimal fake project layout to package, independent of the
+    # real repo's own yasinai/ directory.
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "module.py").write_text("print('hello')\n")
+    (tmp_path / "config.toml").write_text("[tool]\nname = 'demo'\n")
+
+    output_dir = tmp_path / "out"
+    builder = PackageBuilder()
+    res = builder.build_package(
+        name="demo",
+        version="0.1.0",
+        output_directory=str(output_dir),
+        include_paths=[str(tmp_path / "src"), str(tmp_path / "config.toml")],
+    )
+
+    assert res["success"] is True
+    archive_path = res["archive_path"]
+    assert os.path.isfile(archive_path)
+    assert archive_path.endswith("demo-v0.1.0.tar.gz")
+
+    with tarfile.open(archive_path, "r:gz") as tar:
+        members = tar.getnames()
+    assert any(m.endswith("module.py") for m in members)
+    assert any(m.endswith("config.toml") for m in members)
+
+
+def test_package_builder_output_directory_auto_created(tmp_path):
+    output_dir = tmp_path / "nested" / "does" / "not" / "exist"
+    assert not output_dir.exists()
+
+    builder = PackageBuilder()
+    res = builder.build_package(
+        name="demo",
+        version="1.0.0",
+        output_directory=str(output_dir),
+        include_paths=[],
+    )
+
+    assert res["success"] is True
+    assert output_dir.exists()
+    assert os.path.isfile(res["archive_path"])
+
+
+def test_package_builder_skips_missing_paths_without_failing(tmp_path):
+    (tmp_path / "real.txt").write_text("present\n")
+
+    builder = PackageBuilder()
+    res = builder.build_package(
+        name="demo",
+        version="1.0.0",
+        output_directory=str(tmp_path / "out"),
+        include_paths=[str(tmp_path / "real.txt"), str(tmp_path / "does_not_exist.txt")],
+    )
+
+    assert res["success"] is True
+    assert any(f.endswith("real.txt") for f in res["files_included"])
+    assert not any("does_not_exist.txt" in f for f in res["files_included"])
 
 
 # Verified Developer SDK coverage is at 100%

--- a/yasinai/deployment/package_builder.py
+++ b/yasinai/deployment/package_builder.py
@@ -4,9 +4,17 @@ Bundles modules, agents, and plugins into deployable artifacts.
 """
 
 import logging
-from typing import Any, Dict
+import os
+import tarfile
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_INCLUDE_PATHS = (
+    "yasinai/core/",
+    "yasinai/cli/",
+    "pyproject.toml",
+)
 
 
 class PackageBuilder:
@@ -19,26 +27,43 @@ class PackageBuilder:
         name: str,
         version: str = "1.0.0",
         output_directory: str = "dist/",
+        *,
+        include_paths: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """
-        Bundle and package specified component artifacts.
+        Bundle the given paths into a real .tar.gz deployment artifact.
+
+        include_paths defaults to the platform's core/cli/pyproject.toml
+        files if not given, preserving prior behavior. Pass a different
+        list to package a different set of components (e.g. a single
+        plugin directory).
         """
         logger.info(f"Building deployment package '{name}' (version={version}) to directory '{output_directory}'...")
+        paths_to_include = list(include_paths) if include_paths is not None else list(_DEFAULT_INCLUDE_PATHS)
+
         try:
             package_name = f"{name}-pkg-{version}.tar.gz" if "yasinai" in name else f"{name}-v{version}.tar.gz"
+            os.makedirs(output_directory, exist_ok=True)
+            archive_path = os.path.join(output_directory, package_name)
+
+            files_included: List[str] = []
+            with tarfile.open(archive_path, "w:gz") as tar:
+                for path in paths_to_include:
+                    if not os.path.exists(path):
+                        logger.warning(f"Skipping missing path for package '{name}': '{path}'")
+                        continue
+                    tar.add(path, arcname=path)
+                    files_included.append(path)
 
             result = {
                 "success": True,
                 "package_name": package_name,
                 "output_directory": output_directory,
+                "archive_path": os.path.abspath(archive_path),
                 "version": version,
-                "files_included": [
-                    "yasinai/core/",
-                    "yasinai/cli/",
-                    "pyproject.toml"
-                ]
+                "files_included": files_included,
             }
-            logger.info(f"Package successfully built: {package_name}")
+            logger.info(f"Package successfully built: {archive_path}")
             return result
         except Exception as e:
             logger.error(f"Failed to build package '{name}': {e}", exc_info=True)
@@ -46,6 +71,7 @@ class PackageBuilder:
                 "success": False,
                 "package_name": "",
                 "output_directory": output_directory,
+                "archive_path": "",
                 "version": version,
-                "files_included": []
+                "files_included": [],
             }


### PR DESCRIPTION
Fixes #99.

## Changes
`yasinai/deployment/package_builder.py::build_package()` claimed to bundle files into a deployment artifact but only returned a descriptive dict — no archive was ever created.

- Uses stdlib `tarfile` to create a real `.tar.gz` at `{output_directory}/{package_name}`.
- `output_directory` auto-created via `os.makedirs(exist_ok=True)` if missing.
- Added an optional keyword-only `include_paths` parameter, defaulting to the previous hardcoded list (`yasinai/core/`, `yasinai/cli/`, `pyproject.toml`) — existing callers (`yasinai/cli/main.py`) and the original test behavior are unaffected. Pass a different list to package different components.
- `files_included` in the result now reflects what was actually archived (missing paths are skipped with a warning, not silently claimed).
- Result includes a new `archive_path` (absolute path to the created file).
- Error handling shape preserved: invalid input (e.g. `name=None`) still fails and returns `success=False`, same as before — verified this didn't regress when the archiving logic was added.

## Side-effect cleanup (found during verification)
3 existing tests across `test_developer_platform.py`, `test_deployment.py`, and `test_cli.py` called `build_package()` with repo-root-relative output directories (`dist/`, `build/`, `temp/`, `custom_dist/`). These previously passed silently because no file was actually written. Now that archives are real, these were redirected to pytest's `tmp_path` fixture so the repo working tree stays clean across test runs (confirmed via `git status` before/after the full suite).

## Constraints respected
- stdlib only (`tarfile`, `os`) — no new dependency.
- No breaking signature change — `name`, `version`, `output_directory` positional/keyword usage unchanged; `include_paths` is new and keyword-only.

## Tests
3 new tests in `tests/test_developer_platform.py`:
- `test_package_builder_creates_real_archive_on_disk` — builds a package from a fake project layout, verifies the `.tar.gz` exists and inspects its members via `tarfile`.
- `test_package_builder_output_directory_auto_created` — nested missing output directory gets created.
- `test_package_builder_skips_missing_paths_without_failing` — a mix of existing/missing include paths doesn't fail the whole build.

## Verification
Full suite: 284 passed. `git status` clean after full test run (no stray archives left in repo root).
