### PR TITLE
fix: implement bounded provider retry and fallback in GenerationService

### DIFF
--- a/tests/test_generation_service.py
+++ b/tests/test_generation_service.py
@@ -5,7 +5,64 @@ import pytest
 
 from yasinai.contracts import GenerationRequest, GenerationResult, ContractViolationError
 from yasinai.providers import LocalProvider, OpenAIProvider, ProviderRegistry
+from yasinai.providers.base import (
+    GenerationRequest as ProviderGenerationRequest,
+    GenerationResponse,
+    ProviderBase,
+    ProviderCapability,
+    ProviderError,
+    ProviderInfo,
+)
 from yasinai.services import GenerationService
+
+
+class _FlakyProvider(ProviderBase):
+    """Test double: fails N times (retryable or not), then succeeds."""
+
+    def __init__(self, name: str, *, fail_times: int, retryable: bool = True) -> None:
+        self._name = name
+        self._fail_times = fail_times
+        self._retryable = retryable
+        self.call_count = 0
+
+    @property
+    def info(self) -> ProviderInfo:
+        return ProviderInfo(
+            name=self._name,
+            capabilities=[ProviderCapability.GENERATION],
+            model_ids=[],
+        )
+
+    def is_available(self) -> bool:
+        return True
+
+    def _generate(self, request: ProviderGenerationRequest) -> GenerationResponse:
+        self.call_count += 1
+        if self.call_count <= self._fail_times:
+            raise ProviderError(self._name, "simulated failure", retryable=self._retryable)
+        return GenerationResponse(text="ok", model="fake-model", provider=self._name)
+
+
+class _AlwaysFailsProvider(ProviderBase):
+    def __init__(self, name: str, *, retryable: bool = True) -> None:
+        self._name = name
+        self._retryable = retryable
+        self.call_count = 0
+
+    @property
+    def info(self) -> ProviderInfo:
+        return ProviderInfo(
+            name=self._name,
+            capabilities=[ProviderCapability.GENERATION],
+            model_ids=[],
+        )
+
+    def is_available(self) -> bool:
+        return True
+
+    def _generate(self, request: ProviderGenerationRequest) -> GenerationResponse:
+        self.call_count += 1
+        raise ProviderError(self._name, "always fails", retryable=self._retryable)
 
 
 def test_generation_request_validation():
@@ -76,3 +133,88 @@ def test_service_import_surface():
     assert hasattr(services, "GenerationService")
     assert hasattr(contracts, "GenerationRequest")
     assert hasattr(contracts, "GenerationResult")
+
+
+def test_generate_retries_retryable_error_then_succeeds():
+    provider = _FlakyProvider("flaky", fail_times=1, retryable=True)
+    reg = ProviderRegistry()
+    reg.register(provider)
+    svc = GenerationService(registry=reg, retry_backoff_seconds=0.0)
+
+    result = svc.generate(GenerationRequest(prompt="hello"))
+    assert result.success is True
+    assert result.provider == "flaky"
+    assert provider.call_count == 2  # 1 failure + 1 retry that succeeded
+
+
+def test_generate_does_not_retry_non_retryable_error():
+    provider = _FlakyProvider("flaky", fail_times=1, retryable=False)
+    reg = ProviderRegistry()
+    reg.register(provider)
+    svc = GenerationService(registry=reg, retry_backoff_seconds=0.0)
+
+    result = svc.generate(GenerationRequest(prompt="hello"))
+    assert result.success is False
+    assert provider.call_count == 1  # no retry attempted
+
+
+def test_generate_retry_budget_is_bounded():
+    provider = _AlwaysFailsProvider("stubborn", retryable=True)
+    reg = ProviderRegistry()
+    reg.register(provider)
+    svc = GenerationService(
+        registry=reg, retry_backoff_seconds=0.0, max_retries_per_provider=2, max_provider_fallbacks=0
+    )
+
+    result = svc.generate(GenerationRequest(prompt="hello"))
+    assert result.success is False
+    assert provider.call_count == 3  # 1 initial attempt + 2 retries, then gives up
+
+
+def test_generate_falls_back_to_next_provider_when_first_exhausted():
+    failing = _AlwaysFailsProvider("bad", retryable=True)
+    healthy = LocalProvider()
+    reg = ProviderRegistry()
+    reg.register(failing)
+    reg.register(healthy)
+    svc = GenerationService(
+        registry=reg, retry_backoff_seconds=0.0, max_retries_per_provider=1, max_provider_fallbacks=1
+    )
+
+    result = svc.generate(GenerationRequest(prompt="hello"))
+    assert result.success is True
+    assert result.provider == "local"
+    assert failing.call_count == 2  # 1 initial + 1 retry before falling back
+
+
+def test_generate_pinned_provider_is_only_retried_never_substituted():
+    failing = _AlwaysFailsProvider("bad", retryable=True)
+    healthy = LocalProvider()
+    reg = ProviderRegistry()
+    reg.register(failing)
+    reg.register(healthy)
+    svc = GenerationService(
+        registry=reg, retry_backoff_seconds=0.0, max_retries_per_provider=1, max_provider_fallbacks=5
+    )
+
+    result = svc.generate(GenerationRequest(prompt="hello", provider="bad"))
+    assert result.success is False
+    assert result.provider == "bad"
+    assert failing.call_count == 2  # initial + 1 retry, never touches 'healthy'
+
+
+def test_generate_fallback_budget_is_bounded():
+    bad1 = _AlwaysFailsProvider("bad1", retryable=False)
+    bad2 = _AlwaysFailsProvider("bad2", retryable=False)
+    bad3 = _AlwaysFailsProvider("bad3", retryable=False)
+    reg = ProviderRegistry()
+    reg.register(bad1)
+    reg.register(bad2)
+    reg.register(bad3)
+    svc = GenerationService(registry=reg, retry_backoff_seconds=0.0, max_provider_fallbacks=1)
+
+    result = svc.generate(GenerationRequest(prompt="hello"))
+    assert result.success is False
+    # Only 2 providers tried total: primary + 1 fallback (budget=1), third never touched.
+    tried = bad1.call_count + bad2.call_count + bad3.call_count
+    assert tried == 2

--- a/yasinai/services/generation_service.py
+++ b/yasinai/services/generation_service.py
@@ -6,12 +6,14 @@ Phase 3.2: consumers call this (or contracts) instead of yasinai.providers.
 from __future__ import annotations
 
 import logging
-from typing import Optional
+import time
+from typing import List, Optional
 
 from yasinai.contracts.base import CapabilityMetadata
 from yasinai.contracts.generation import GenerationRequest, GenerationResult
 from yasinai.providers.base import (
     GenerationRequest as ProviderGenerationRequest,
+    ProviderBase,
     ProviderCapability,
     ProviderError,
 )
@@ -36,74 +38,124 @@ class GenerationService:
         router: Optional[ProviderRouter] = None,
         *,
         default_capability: ProviderCapability = ProviderCapability.GENERATION,
+        max_retries_per_provider: int = 1,
+        retry_backoff_seconds: float = 0.1,
+        max_provider_fallbacks: int = 2,
     ) -> None:
         self._registry = registry if registry is not None else build_default_registry()
         self._router = router if router is not None else ProviderRouter(self._registry)
         self._default_capability = default_capability
+        self._max_retries_per_provider = max(0, max_retries_per_provider)
+        self._retry_backoff_seconds = max(0.0, retry_backoff_seconds)
+        self._max_provider_fallbacks = max(0, max_provider_fallbacks)
 
     def generate(self, request: GenerationRequest) -> GenerationResult:
-        """Execute a generation request; always returns GenerationResult."""
+        """Execute a generation request; always returns GenerationResult.
+
+        Retries the selected provider on retryable errors (bounded by
+        max_retries_per_provider, with a short backoff between attempts).
+        If a provider is exhausted and the caller did not pin a specific
+        provider name, falls back to the next available candidate for the
+        capability (bounded by max_provider_fallbacks). A caller-pinned
+        provider (request.provider set) is only retried, never substituted.
+        """
         meta = CapabilityMetadata(capability="generation")
+        internal = ProviderGenerationRequest(
+            prompt=request.prompt,
+            model=request.model,
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+            system_prompt=request.system_prompt,
+            stop_sequences=list(request.stop_sequences or []),
+            metadata=dict(request.metadata or {}),
+        )
+
         try:
-            provider = self._select_provider(request)
-            internal = ProviderGenerationRequest(
-                prompt=request.prompt,
-                model=request.model,
-                max_tokens=request.max_tokens,
-                temperature=request.temperature,
-                system_prompt=request.system_prompt,
-                stop_sequences=list(request.stop_sequences or []),
-                metadata=dict(request.metadata or {}),
-            )
-            response = provider.generate(internal)
-            return GenerationResult(
-                success=True,
-                text=response.text,
-                model=response.model,
-                provider=response.provider,
-                input_tokens=response.input_tokens,
-                output_tokens=response.output_tokens,
-                finish_reason=response.finish_reason,
-                meta=CapabilityMetadata(
-                    capability="generation",
-                    provider=response.provider,
-                ),
-            )
+            candidates = self._candidate_providers(request)
         except ProviderUnavailableError as exc:
             logger.warning("Generation unavailable: %s", exc)
-            return GenerationResult(
-                success=False,
-                error=str(exc),
-                meta=meta,
-            )
-        except ProviderError as exc:
-            logger.warning("Provider error: %s", exc)
-            return GenerationResult(
-                success=False,
-                error=str(exc),
-                provider=getattr(exc, "provider", None),
-                meta=CapabilityMetadata(
-                    capability="generation",
-                    provider=getattr(exc, "provider", None),
-                ),
-            )
-        except Exception as exc:  # noqa: BLE001 — facade must not leak
-            logger.exception("GenerationService.generate failed")
             return GenerationResult(success=False, error=str(exc), meta=meta)
 
-    def _select_provider(self, request: GenerationRequest):
+        pinned = bool(request.provider)
+        fallbacks_used = 0
+        last_error: Optional[ProviderError] = None
+
+        for candidate in candidates:
+            attempt = 0
+            while True:
+                try:
+                    response = candidate.generate(internal)
+                    return GenerationResult(
+                        success=True,
+                        text=response.text,
+                        model=response.model,
+                        provider=response.provider,
+                        input_tokens=response.input_tokens,
+                        output_tokens=response.output_tokens,
+                        finish_reason=response.finish_reason,
+                        meta=CapabilityMetadata(
+                            capability="generation",
+                            provider=response.provider,
+                        ),
+                    )
+                except ProviderError as exc:
+                    last_error = exc
+                    if exc.retryable and attempt < self._max_retries_per_provider:
+                        attempt += 1
+                        logger.warning(
+                            "Provider '%s' failed (retryable), attempt %d/%d: %s",
+                            candidate.info.name, attempt, self._max_retries_per_provider, exc,
+                        )
+                        if self._retry_backoff_seconds:
+                            time.sleep(self._retry_backoff_seconds * attempt)
+                        continue
+                    logger.warning(
+                        "Provider '%s' failed (retryable=%s), giving up on this provider: %s",
+                        candidate.info.name, exc.retryable, exc,
+                    )
+                    break
+                except Exception as exc:  # noqa: BLE001 — facade must not leak
+                    logger.exception("GenerationService.generate failed")
+                    return GenerationResult(success=False, error=str(exc), meta=meta)
+
+            if pinned or fallbacks_used >= self._max_provider_fallbacks:
+                break
+            fallbacks_used += 1
+
+        assert last_error is not None  # candidates is non-empty, loop always sets this on failure
+        return GenerationResult(
+            success=False,
+            error=str(last_error),
+            provider=getattr(last_error, "provider", None),
+            meta=CapabilityMetadata(
+                capability="generation",
+                provider=getattr(last_error, "provider", None),
+            ),
+        )
+
+    def _candidate_providers(self, request: GenerationRequest) -> List[ProviderBase]:
+        """Return an ordered list of providers to try for this request.
+
+        A caller-pinned request.provider yields exactly one candidate (no
+        substitution). Otherwise, returns available providers for the
+        capability ordered by the router's selection policy, so fallback
+        tries alternates in the same order the router would prefer them.
+        """
         if request.provider:
             named = self._registry.get(request.provider)
-            if named is None:
-                raise ProviderUnavailableError(
-                    self._default_capability, request.model
-                )
-            if not named.is_available():
-                raise ProviderUnavailableError(
-                    self._default_capability, request.model
-                )
-            return named
-        return self._router.select(self._default_capability, model=request.model)
+            if named is None or not named.is_available():
+                raise ProviderUnavailableError(self._default_capability, request.model)
+            return [named]
+
+        # Prime the ordered candidate list via the router (respects model
+        # hint matching), then include any other available providers for
+        # this capability as further fallback candidates.
+        primary = self._router.select(self._default_capability, model=request.model)
+        rest = [
+            p for p in self._registry.available_for_capability(self._default_capability)
+            if p is not primary
+        ]
+        return [primary, *rest]
 
     @property
     def registry(self) -> ProviderRegistry:


### PR DESCRIPTION
Fixes #109.

## Changes
`ProviderError.retryable` was set correctly by adapters but never consulted by `GenerationService.generate()` — any failure surfaced immediately with no retry or fallback.

- `generate()` retries the selected provider up to `max_retries_per_provider` (default 1) with linear backoff (`retry_backoff_seconds`, default 0.1s) on `retryable=True` errors.
- Non-retryable errors fail immediately (no retry), matching prior behavior for that case.
- When a provider's retry budget is exhausted, falls back to the next available provider for the capability, bounded by `max_provider_fallbacks` (default 2).
- A caller-pinned `request.provider` is only retried, never substituted — explicit provider choice is respected.
- All three knobs are constructor parameters, so `max_retries_per_provider=0` restores the old fail-fast behavior if needed.

## Constraints respected
- No priority/cost/health-aware routing — retry/fallback only.
- Unexpected (non-`ProviderError`) exceptions still fail immediately without retry, same as before.
- `ProviderRouter.select()` model-matching semantics untouched.

## Tests
6 new tests in `tests/test_generation_service.py` using lightweight fake providers (`_FlakyProvider`, `_AlwaysFailsProvider`):
- retry-then-succeed on a retryable error
- no retry on a non-retryable error
- bounded retry budget (exact call count verified)
- fallback to a healthy second provider once the first is exhausted
- pinned provider is only retried, never substituted
- fallback budget bounded across multiple failing providers

## Verification
Full suite: 290 passed (up from 284 baseline + 6 new).
