### PR TITLE
fix: configure SQLite WAL mode and busy_timeout in knowledge_platform stores

### DIFF
--- a/knowledge_platform/memory_store.py
+++ b/knowledge_platform/memory_store.py
@@ -17,6 +17,9 @@ class SQLiteMemoryStore:
             self.path.parent.mkdir(parents=True, exist_ok=True)
         self._connection = sqlite3.connect(str(self.path))
         self._connection.row_factory = sqlite3.Row
+        self._connection.execute("PRAGMA busy_timeout = 5000")
+        if str(self.path) != ":memory:":
+            self._connection.execute("PRAGMA journal_mode = WAL")
         self._connection.execute(
             """
             CREATE TABLE IF NOT EXISTS memories (

--- a/knowledge_platform/vector_store.py
+++ b/knowledge_platform/vector_store.py
@@ -17,6 +17,9 @@ class SQLiteVectorStore:
             self.path.parent.mkdir(parents=True, exist_ok=True)
         self._connection = sqlite3.connect(str(self.path))
         self._connection.row_factory = sqlite3.Row
+        self._connection.execute("PRAGMA busy_timeout = 5000")
+        if str(self.path) != ":memory:":
+            self._connection.execute("PRAGMA journal_mode = WAL")
         self._connection.execute(
             """
             CREATE TABLE IF NOT EXISTS vectors (

--- a/tests/test_knowledge_persistence.py
+++ b/tests/test_knowledge_persistence.py
@@ -36,3 +36,21 @@ def test_sqlite_vector_store_update_delete_and_clear(tmp_path):
     store.clear()
     assert store.get_all_records() == []
     store.close()
+
+
+def test_sqlite_vector_store_sets_wal_and_busy_timeout(tmp_path):
+    store = SQLiteVectorStore(tmp_path / "vectors.db")
+    journal_mode = store._connection.execute("PRAGMA journal_mode").fetchone()[0]
+    busy_timeout = store._connection.execute("PRAGMA busy_timeout").fetchone()[0]
+    assert journal_mode.lower() == "wal"
+    assert busy_timeout == 5000
+    store.close()
+
+
+def test_sqlite_vector_store_in_memory_skips_wal_but_sets_busy_timeout():
+    store = SQLiteVectorStore(":memory:")
+    journal_mode = store._connection.execute("PRAGMA journal_mode").fetchone()[0]
+    busy_timeout = store._connection.execute("PRAGMA busy_timeout").fetchone()[0]
+    assert journal_mode.lower() != "wal"
+    assert busy_timeout == 5000
+    store.close()

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -23,6 +23,26 @@ def test_sqlite_memory_store_round_trip_and_update(tmp_path):
     store.close()
 
 
+def test_sqlite_memory_store_sets_wal_and_busy_timeout(tmp_path):
+    path = tmp_path / "memory.db"
+    store = SQLiteMemoryStore(path)
+    journal_mode = store._connection.execute("PRAGMA journal_mode").fetchone()[0]
+    busy_timeout = store._connection.execute("PRAGMA busy_timeout").fetchone()[0]
+    assert journal_mode.lower() == "wal"
+    assert busy_timeout == 5000
+    store.close()
+
+
+def test_sqlite_memory_store_in_memory_skips_wal_but_sets_busy_timeout():
+    store = SQLiteMemoryStore(":memory:")
+    journal_mode = store._connection.execute("PRAGMA journal_mode").fetchone()[0]
+    busy_timeout = store._connection.execute("PRAGMA busy_timeout").fetchone()[0]
+    # WAL is not applicable to :memory: databases; SQLite keeps its default.
+    assert journal_mode.lower() != "wal"
+    assert busy_timeout == 5000
+    store.close()
+
+
 def test_long_term_memory_defaults_to_durable_store(tmp_path):
     path = tmp_path / "memory.db"
     first = LongTermMemory(path=str(path))


### PR DESCRIPTION
Fixes #113.

## Changes
`SQLiteMemoryStore` and `SQLiteVectorStore` (both in `knowledge_platform/`) opened plain `sqlite3.connect()` calls with no journal mode or busy timeout configured — default rollback-journal mode locks the whole file for writers, with no built-in retry on lock contention.

- Both stores now set `PRAGMA busy_timeout = 5000` immediately after connecting (applies to file-backed and `:memory:` databases alike).
- Both stores now set `PRAGMA journal_mode = WAL` for file-backed databases, enabling concurrent readers alongside a writer.
- WAL is skipped for `:memory:` databases (not applicable there), guarded the same way the existing directory-creation check already distinguishes `:memory:`.

## Constraints respected
- No public API changes — constructor signatures and all other connection/schema setup untouched.
- No new dependency — stdlib `sqlite3` pragmas only.

## Tests
4 new tests (2 per store) verifying the pragmas are actually active on the open connection via `PRAGMA journal_mode` / `PRAGMA busy_timeout` queries, covering both file-backed and `:memory:` cases.

## Verification
Full suite: 296 passed (up from 292 baseline + 4 new).
