### PR TITLE
fix: add Ruff lint check to CI (non-blocking) and fix safe auto-fixable violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,33 @@ jobs:
           path: coverage.xml
           if-no-files-found: ignore
 
+  lint:
+    name: Lint (Ruff, non-blocking)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install lint tooling
+        run: python -m pip install --upgrade pip && python -m pip install -e ".[lint]"
+
+      - name: Run Ruff
+        # Non-blocking: 594 pre-existing violations (mostly legacy typing
+        # style) are tracked in issue #116, not fixed here. This step
+        # reports the current baseline in CI output without failing the
+        # build. Flip continue-on-error to false once the backlog is
+        # cleared (see #116).
+        continue-on-error: true
+        run: ruff check . --output-format=github
+
   security:
     name: Security quality gate
     runs-on: ubuntu-latest

--- a/api_service/app.py
+++ b/api_service/app.py
@@ -6,8 +6,9 @@ HTTP/CLI adapters can depend on this layer without coupling the core to a web fr
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Mapping, Optional
+from typing import Any, Callable, Dict, Optional
 
 from .errors import APIError, ValidationError
 from .models import HealthResponse, ServiceResponse

--- a/api_service/models.py
+++ b/api_service/models.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict
 
+
 @dataclass(frozen=True)
 class ServiceResponse:
     status: int

--- a/developer_platform/__init__.py
+++ b/developer_platform/__init__.py
@@ -4,17 +4,36 @@ Provides SDKs and tools for creating and managing AI extensions, agents, plugins
 """
 
 from developer_platform.agent import Agent, AgentSDK
-from developer_platform.plugin import Plugin, PluginSDK
 from developer_platform.app import AIApplication, AppSDK
+from developer_platform.debugger import Debugger
 from developer_platform.extension import ExtensionAPI
 from developer_platform.generator import Generator
-from developer_platform.debugger import Debugger
-from developer_platform.profiler import Profiler
 from developer_platform.package_builder import PackageBuilder
-from developer_platform.sdk import PluginError, PluginRegistry, PluginSpec, SDKError, plugin
+from developer_platform.plugin import Plugin, PluginSDK
+from developer_platform.profiler import Profiler
+from developer_platform.sdk import (
+    PluginError,
+    PluginRegistry,
+    PluginSpec,
+    SDKError,
+    plugin,
+)
 
 __all__ = [
-    "Agent", "AgentSDK", "Plugin", "PluginSDK", "AIApplication", "AppSDK",
-    "ExtensionAPI", "Generator", "Debugger", "Profiler", "PackageBuilder",
-    "PluginError", "PluginRegistry", "PluginSpec", "SDKError", "plugin",
+    "AIApplication",
+    "Agent",
+    "AgentSDK",
+    "AppSDK",
+    "Debugger",
+    "ExtensionAPI",
+    "Generator",
+    "PackageBuilder",
+    "Plugin",
+    "PluginError",
+    "PluginRegistry",
+    "PluginSDK",
+    "PluginSpec",
+    "Profiler",
+    "SDKError",
+    "plugin",
 ]

--- a/developer_platform/app.py
+++ b/developer_platform/app.py
@@ -5,6 +5,7 @@ Provides building blocks for creating AI-powered applications.
 
 import logging
 from typing import Any, Dict, List, Optional
+
 from developer_platform.agent import Agent
 from developer_platform.plugin import Plugin
 from developer_platform.sdk import PluginTrustError

--- a/developer_platform/profiler.py
+++ b/developer_platform/profiler.py
@@ -5,7 +5,7 @@ Measures execution times and resource utilization metrics.
 
 import logging
 import time
-from typing import Dict, Any
+from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
 

--- a/developer_platform/sdk.py
+++ b/developer_platform/sdk.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Iterable, Optional
+from typing import Any, Callable, Dict, Optional
 
 
 class SDKError(Exception):
@@ -86,18 +87,7 @@ def plugin(
     """Declare plugin metadata without coupling the handler to the registry."""
 
     def decorator(handler: Callable[..., Any]) -> Callable[..., Any]:
-        setattr(
-            handler,
-            "__yasinai_plugin__",
-            PluginSpec(
-                name,
-                handler,
-                version,
-                description,
-                dict(metadata or {}),
-                trusted=trusted,
-            ),
-        )
+        handler.__yasinai_plugin__ = PluginSpec(name, handler, version, description, dict(metadata or {}), trusted=trusted)
         return handler
 
     return decorator
@@ -105,9 +95,9 @@ def plugin(
 
 __all__ = [
     "PluginError",
-    "PluginTrustError",
     "PluginRegistry",
     "PluginSpec",
+    "PluginTrustError",
     "SDKError",
     "plugin",
 ]

--- a/knowledge_platform/__init__.py
+++ b/knowledge_platform/__init__.py
@@ -3,36 +3,45 @@ YasinAI Knowledge Platform.
 Exposes public APIs for Memory System, Knowledge Graph, Semantic Search, Context Engine, and Reasoning.
 """
 
-from knowledge_platform.memory import ShortTermMemory, LongTermMemory, MemoryManager
-from knowledge_platform.memory_store import SQLiteMemoryStore
+from knowledge_platform.context import (
+    ContextBuilder,
+    ConversationMemory,
+    ReasoningEngine,
+)
 from knowledge_platform.entity import Entity
-from knowledge_platform.relation import Relation
-from knowledge_platform.triple_store import TripleStore
-from knowledge_platform.query_engine import QueryEngine
 from knowledge_platform.graph import KnowledgeGraph
-from knowledge_platform.semantic_search import EmbeddingEngine, VectorStore, SemanticSearch, Retriever
-from knowledge_platform.vector_store import SQLiteVectorStore
-from knowledge_platform.context import ConversationMemory, ContextBuilder, ReasoningEngine
+from knowledge_platform.memory import LongTermMemory, MemoryManager, ShortTermMemory
+from knowledge_platform.memory_store import SQLiteMemoryStore
+from knowledge_platform.query_engine import QueryEngine
 from knowledge_platform.reasoning import KnowledgeReasoner, RuleEngine
+from knowledge_platform.relation import Relation
+from knowledge_platform.semantic_search import (
+    EmbeddingEngine,
+    Retriever,
+    SemanticSearch,
+    VectorStore,
+)
+from knowledge_platform.triple_store import TripleStore
+from knowledge_platform.vector_store import SQLiteVectorStore
 
 __all__ = [
-    "ShortTermMemory",
+    "ContextBuilder",
+    "ConversationMemory",
+    "EmbeddingEngine",
+    "Entity",
+    "KnowledgeGraph",
+    "KnowledgeReasoner",
     "LongTermMemory",
     "MemoryManager",
-    "SQLiteMemoryStore",
-    "Entity",
-    "Relation",
-    "TripleStore",
     "QueryEngine",
-    "KnowledgeGraph",
-    "EmbeddingEngine",
-    "VectorStore",
+    "ReasoningEngine",
+    "Relation",
+    "Retriever",
+    "RuleEngine",
+    "SQLiteMemoryStore",
     "SQLiteVectorStore",
     "SemanticSearch",
-    "Retriever",
-    "ConversationMemory",
-    "ContextBuilder",
-    "ReasoningEngine",
-    "KnowledgeReasoner",
-    "RuleEngine",
+    "ShortTermMemory",
+    "TripleStore",
+    "VectorStore",
 ]

--- a/knowledge_platform/context.py
+++ b/knowledge_platform/context.py
@@ -4,7 +4,7 @@ Implements ConversationMemory, ContextBuilder, and ReasoningEngine.
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Dict, List
 
 logger = logging.getLogger(__name__)
 

--- a/knowledge_platform/graph.py
+++ b/knowledge_platform/graph.py
@@ -6,9 +6,9 @@ import logging
 from typing import Dict, List, Optional, Tuple
 
 from knowledge_platform.entity import Entity
+from knowledge_platform.query_engine import QueryEngine
 from knowledge_platform.relation import Relation
 from knowledge_platform.triple_store import TripleStore
-from knowledge_platform.query_engine import QueryEngine
 
 logger = logging.getLogger(__name__)
 

--- a/knowledge_platform/query_engine.py
+++ b/knowledge_platform/query_engine.py
@@ -3,7 +3,8 @@ Query Engine for YasinAI Knowledge Graph.
 """
 
 import logging
-from typing import Any, List, Dict, Tuple, Optional
+from typing import List, Optional, Tuple
+
 from knowledge_platform.triple_store import TripleStore
 
 logger = logging.getLogger(__name__)

--- a/knowledge_platform/reasoning.py
+++ b/knowledge_platform/reasoning.py
@@ -4,7 +4,8 @@ Implements KnowledgeReasoner and RuleEngine.
 """
 
 import logging
-from typing import Any, Dict, List, Tuple, Callable
+from typing import Any, Callable, Dict, List, Tuple
+
 from knowledge_platform.graph import KnowledgeGraph
 
 logger = logging.getLogger(__name__)

--- a/knowledge_platform/semantic_search.py
+++ b/knowledge_platform/semantic_search.py
@@ -182,4 +182,4 @@ class Retriever:
             close()
 
 
-__all__ = ["EmbeddingEngine", "VectorStore", "SQLiteVectorStore", "SemanticSearch", "Retriever"]
+__all__ = ["EmbeddingEngine", "Retriever", "SQLiteVectorStore", "SemanticSearch", "VectorStore"]

--- a/knowledge_platform/triple_store.py
+++ b/knowledge_platform/triple_store.py
@@ -3,7 +3,7 @@ Triple Store for YasinAI Knowledge Graph.
 """
 
 import logging
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ test = [
     "pytest>=7.4,<10",
     "pytest-cov>=6,<8",
 ]
+lint = [
+    "ruff==0.16.3",
+]
 
 [project.scripts]
 yasin = "yasinai.cli.security_entrypoint:main"
@@ -62,3 +65,7 @@ exclude_also = [
 ]
 show_missing = true
 skip_covered = false
+
+[tool.ruff]
+target-version = "py39"
+line-length = 120

--- a/security_platform/__init__.py
+++ b/security_platform/__init__.py
@@ -3,27 +3,27 @@ YasinAI Security Platform.
 Exposes public APIs for Identity, Authentication, Authorization, Encryption, Monitoring, and Security Scanning.
 """
 
-from security_platform.identity import Role, User, IdentityManager
-from security_platform.auth import Session, AuthManager
+from security_platform.auth import AuthManager, Session
 from security_platform.authorization import Permission, Policy, PolicyEngine
 from security_platform.encryption import EncryptionEngine, SecretStore
-from security_platform.monitoring import SecurityEvent, AuditLogger, ThreatDetector
+from security_platform.identity import IdentityManager, Role, User
+from security_platform.monitoring import AuditLogger, SecurityEvent, ThreatDetector
 from security_platform.scanner import SecurityFinding, SecurityScanner
 
 __all__ = [
-    "Role",
-    "User",
-    "IdentityManager",
-    "Session",
+    "AuditLogger",
     "AuthManager",
+    "EncryptionEngine",
+    "IdentityManager",
     "Permission",
     "Policy",
     "PolicyEngine",
-    "EncryptionEngine",
+    "Role",
     "SecretStore",
     "SecurityEvent",
-    "AuditLogger",
-    "ThreatDetector",
     "SecurityFinding",
     "SecurityScanner",
+    "Session",
+    "ThreatDetector",
+    "User",
 ]

--- a/security_platform/auth.py
+++ b/security_platform/auth.py
@@ -8,7 +8,8 @@ import hmac
 import logging
 import secrets
 import time
-from typing import Dict, Optional, Set
+from typing import Dict, Optional
+
 from security_platform.identity import IdentityManager
 
 logger = logging.getLogger(__name__)

--- a/security_platform/authorization.py
+++ b/security_platform/authorization.py
@@ -5,7 +5,8 @@ Manages permissions, policies, access rules, and role-based access control (RBAC
 
 import logging
 from typing import Dict, List, Optional, Set
-from security_platform.identity import IdentityManager, User
+
+from security_platform.identity import IdentityManager
 
 logger = logging.getLogger(__name__)
 

--- a/security_platform/scanner.py
+++ b/security_platform/scanner.py
@@ -8,9 +8,10 @@ intelligence.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, List, Optional
 
 
 @dataclass
@@ -91,6 +92,7 @@ class SecurityScanner:
     def check_crypto(self) -> SecurityFinding:
         try:
             from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
             from security_platform.encryption import EncryptionEngine
             if AESGCM is None or not hasattr(EncryptionEngine, "encrypt"):
                 raise RuntimeError("required AEAD implementation is unavailable")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import os
 import tempfile
 from pathlib import Path
 
-
 _BASE = Path(tempfile.gettempdir())
 _TEST_MEMORY_PATH = _BASE / f"yasinai-tests-{os.getpid()}.db"
 _TEST_VECTOR_PATH = _BASE / f"yasinai-vectors-{os.getpid()}.db"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,16 +1,18 @@
+import argparse
 import json
 import sys
 from unittest.mock import MagicMock, patch
+
 import pytest
-import argparse
+
 from yasinai.cli.main import (
     create_parser,
-    handle_status,
     handle_agent_create,
     handle_memory_search,
-    handle_security_check,
     handle_package_build,
-    main
+    handle_security_check,
+    handle_status,
+    main,
 )
 
 
@@ -55,6 +57,7 @@ def test_handle_serve_invalid_interval(capsys):
 def test_serve_command_loop(mock_run_all, mock_sleep, capsys):
     import os
     import signal
+
     from yasinai.cli.main import handle_serve
     mock_run_all.return_value = {"success": True, "status": "HEALTHY"}
     args = argparse.Namespace(interval=5, json=False)
@@ -79,6 +82,7 @@ def test_serve_command_loop(mock_run_all, mock_sleep, capsys):
 def test_serve_command_json_output(mock_run_all, mock_sleep, capsys):
     import os
     import signal
+
     from yasinai.cli.main import handle_serve
     mock_run_all.return_value = {"success": True, "status": "HEALTHY"}
     args = argparse.Namespace(interval=1, json=True)
@@ -109,6 +113,7 @@ def test_serve_command_json_output(mock_run_all, mock_sleep, capsys):
 def test_serve_command_graceful_shutdown(mock_run_all, mock_sleep, capsys):
     import os
     import signal
+
     from yasinai.cli.main import handle_serve
     mock_run_all.return_value = {"success": False, "status": "DEGRADED"}
     args = argparse.Namespace(interval=5, json=False)
@@ -432,8 +437,8 @@ def test_additional_cli_coverage(capsys):
         assert exc_info.value.code == 0
 
     # 8. Run as main script via subprocess to execute lines 302 and 339
-    import subprocess
     import os
+    import subprocess
     env = os.environ.copy()
     env["PYTHONPATH"] = "."
     res = subprocess.run([sys.executable, "yasinai/cli/main.py", "--help"], capture_output=True, text=True, env=env)

--- a/tests/test_concrete_providers.py
+++ b/tests/test_concrete_providers.py
@@ -16,7 +16,6 @@ from yasinai.providers import (
 from yasinai.providers.base import GenerationRequest
 from yasinai.providers.router import ProviderUnavailableError
 
-
 # ---------------------------------------------------------------------------
 # LocalProvider
 # ---------------------------------------------------------------------------
@@ -116,6 +115,7 @@ def test_openai_bad_response_shape():
 
 def test_openai_http_error_message_redacted(monkeypatch):
     import urllib.error
+
     from yasinai.providers import openai_provider as mod
 
     class FakeHTTPError(urllib.error.HTTPError):

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -12,20 +12,28 @@ from yasinai.contracts.base import (
     ContractViolationError,
     ObservabilityContext,
 )
-from yasinai.contracts.memory import MemoryEntry, MemoryRequest, MemoryResponse, MemoryType
+from yasinai.contracts.embedding import (
+    EmbeddingRequest,
+    EmbeddingResponse,
+    EmbeddingVector,
+)
 from yasinai.contracts.knowledge import (
     KnowledgeEntry,
     KnowledgeQuery,
     KnowledgeQueryType,
     KnowledgeResult,
 )
-from yasinai.contracts.embedding import EmbeddingRequest, EmbeddingResponse, EmbeddingVector
+from yasinai.contracts.memory import (
+    MemoryEntry,
+    MemoryRequest,
+    MemoryResponse,
+    MemoryType,
+)
 from yasinai.contracts.plugin import (
     PluginContract,
     PluginInvokeRequest,
     PluginInvokeResponse,
 )
-
 
 # ---------------------------------------------------------------------------
 # Contract version

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,10 +1,9 @@
 import os
-import json
-import pytest
 from unittest.mock import MagicMock, patch
-from yasinai.deployment.installer import Installer
+
 from yasinai.deployment.docker_manager import DockerManager
 from yasinai.deployment.health_check import HealthCheck
+from yasinai.deployment.installer import Installer
 from yasinai.deployment.package_builder import PackageBuilder
 
 
@@ -179,7 +178,7 @@ def test_additional_deployment_coverage(tmp_path):
 
     # DockerManager generate files IOError (lines 91-92, 101-102)
     # Mocking open to raise IOError when writing
-    with patch("builtins.open", side_effect=IOError("Disk full")):
+    with patch("builtins.open", side_effect=OSError("Disk full")):
         res = manager.generate_docker_files(overwrite=True)
         assert res["dockerfile_created"] is False
         assert res["compose_created"] is False
@@ -220,7 +219,7 @@ def test_additional_deployment_coverage(tmp_path):
         assert "Environment verification failed" in res["message"]
 
     # Installer environment template creation IOError (lines 101-102)
-    with patch("builtins.open", side_effect=IOError("Cannot open file")):
+    with patch("builtins.open", side_effect=OSError("Cannot open file")):
         res = installer.install()
         assert res["success"] is True  # installation is successful but configuration creation is logged and skipped
         assert res["config_created"] is False

--- a/tests/test_developer_platform.py
+++ b/tests/test_developer_platform.py
@@ -1,14 +1,15 @@
 import os
 
 import pytest
+
 from developer_platform.agent import Agent, AgentSDK
-from developer_platform.plugin import Plugin, PluginSDK
 from developer_platform.app import AIApplication, AppSDK
+from developer_platform.debugger import Debugger
 from developer_platform.extension import ExtensionAPI
 from developer_platform.generator import Generator
-from developer_platform.debugger import Debugger
-from developer_platform.profiler import Profiler
 from developer_platform.package_builder import PackageBuilder
+from developer_platform.plugin import Plugin, PluginSDK
+from developer_platform.profiler import Profiler
 from developer_platform.sdk import PluginTrustError
 
 

--- a/tests/test_generation_service.py
+++ b/tests/test_generation_service.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 
 import pytest
 
-from yasinai.contracts import GenerationRequest, GenerationResult, ContractViolationError
+from yasinai.contracts import (
+    ContractViolationError,
+    GenerationRequest,
+    GenerationResult,
+)
 from yasinai.providers import LocalProvider, OpenAIProvider, ProviderRegistry
 from yasinai.providers.base import (
     GenerationRequest as ProviderGenerationRequest,
+)
+from yasinai.providers.base import (
     GenerationResponse,
     ProviderBase,
     ProviderCapability,
@@ -131,8 +137,7 @@ def test_default_registry_includes_local(monkeypatch):
 
 
 def test_service_import_surface():
-    from yasinai import services
-    from yasinai import contracts
+    from yasinai import contracts, services
 
     assert hasattr(services, "GenerationService")
     assert hasattr(contracts, "GenerationRequest")

--- a/tests/test_integration_agent.py
+++ b/tests/test_integration_agent.py
@@ -10,7 +10,6 @@ from yasinai.integration import YasinAgentClient
 from yasinai.providers import LocalProvider, ProviderRegistry
 from yasinai.services import GenerationService, KnowledgeService, RagService
 
-
 FORBIDDEN_IMPORT_ROOTS = (
     "knowledge_platform",
     "developer_platform",
@@ -27,8 +26,8 @@ def client(tmp_path, monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-    from knowledge_platform.memory import MemoryManager
     from knowledge_platform.graph import KnowledgeGraph
+    from knowledge_platform.memory import MemoryManager
     from knowledge_platform.semantic_search import Retriever
 
     knowledge = KnowledgeService(

--- a/tests/test_integration_cli.py
+++ b/tests/test_integration_cli.py
@@ -18,8 +18,8 @@ def cli(tmp_path, monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-    from knowledge_platform.memory import MemoryManager
     from knowledge_platform.graph import KnowledgeGraph
+    from knowledge_platform.memory import MemoryManager
     from knowledge_platform.semantic_search import Retriever
 
     knowledge = KnowledgeService(

--- a/tests/test_integration_hub.py
+++ b/tests/test_integration_hub.py
@@ -19,8 +19,8 @@ def hub(tmp_path, monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-    from knowledge_platform.memory import MemoryManager
     from knowledge_platform.graph import KnowledgeGraph
+    from knowledge_platform.memory import MemoryManager
     from knowledge_platform.semantic_search import Retriever
 
     knowledge = KnowledgeService(

--- a/tests/test_integration_relay_feed_press.py
+++ b/tests/test_integration_relay_feed_press.py
@@ -18,8 +18,8 @@ def services(tmp_path, monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-    from knowledge_platform.memory import MemoryManager
     from knowledge_platform.graph import KnowledgeGraph
+    from knowledge_platform.memory import MemoryManager
     from knowledge_platform.semantic_search import Retriever
 
     knowledge = KnowledgeService(

--- a/tests/test_knowledge_platform.py
+++ b/tests/test_knowledge_platform.py
@@ -3,18 +3,25 @@ Unit Tests for YasinAI Knowledge Platform.
 Covers Memory, Knowledge Graph, Semantic Search, Context Engine, and Reasoning.
 """
 
-import time
 import pytest
-from knowledge_platform.memory import ShortTermMemory, LongTermMemory, MemoryManager
-from knowledge_platform.entity import Entity
-from knowledge_platform.relation import Relation
-from knowledge_platform.triple_store import TripleStore
-from knowledge_platform.query_engine import QueryEngine
-from knowledge_platform.graph import KnowledgeGraph
-from knowledge_platform.semantic_search import EmbeddingEngine, VectorStore, SemanticSearch, Retriever
-from knowledge_platform.context import ConversationMemory, ContextBuilder, ReasoningEngine
-from knowledge_platform.reasoning import KnowledgeReasoner, RuleEngine
 
+from knowledge_platform.context import (
+    ContextBuilder,
+    ConversationMemory,
+    ReasoningEngine,
+)
+from knowledge_platform.entity import Entity
+from knowledge_platform.graph import KnowledgeGraph
+from knowledge_platform.memory import LongTermMemory, MemoryManager, ShortTermMemory
+from knowledge_platform.reasoning import KnowledgeReasoner, RuleEngine
+from knowledge_platform.relation import Relation
+from knowledge_platform.semantic_search import (
+    EmbeddingEngine,
+    Retriever,
+    SemanticSearch,
+    VectorStore,
+)
+from knowledge_platform.triple_store import TripleStore
 
 # --- Memory Tests ---
 

--- a/tests/test_knowledge_service.py
+++ b/tests/test_knowledge_service.py
@@ -17,12 +17,10 @@ from yasinai.contracts.knowledge import (
 )
 from yasinai.contracts.memory import (
     MemoryRequest,
-    MemoryResponse,
     MemoryType,
 )
 from yasinai.services import KnowledgeService
 from yasinai.services.knowledge_service import KnowledgeService as KS
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -33,8 +31,8 @@ def svc(tmp_path, monkeypatch):
     """Isolated service with temp long-term memory and vector paths."""
     monkeypatch.setenv("YASINAI_MEMORY_PATH", str(tmp_path / "mem.db"))
     monkeypatch.setenv("YASINAI_VECTOR_PATH", str(tmp_path / "vectors.db"))
-    from knowledge_platform.memory import MemoryManager
     from knowledge_platform.graph import KnowledgeGraph
+    from knowledge_platform.memory import MemoryManager
     from knowledge_platform.semantic_search import Retriever
 
     return KnowledgeService(

--- a/tests/test_plugin_trust_policy.py
+++ b/tests/test_plugin_trust_policy.py
@@ -12,7 +12,6 @@ from developer_platform.sdk import (
     plugin,
 )
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_production_readiness.py
+++ b/tests/test_production_readiness.py
@@ -75,12 +75,20 @@ def test_release_checklist_mentions_phase_gates():
 
 def test_public_imports_smoke():
     from yasinai.contracts import GenerationRequest, RagRequest
-    from yasinai.services import GenerationService, KnowledgeService, RagService
     from yasinai.integration import (
-        YasinAgentClient, YasinCLIClient, YasinFeedClient,
-        YasinHubClient, YasinPressClient, YasinRelayClient,
+        YasinAgentClient,
+        YasinCLIClient,
+        YasinFeedClient,
+        YasinHubClient,
+        YasinPressClient,
+        YasinRelayClient,
     )
-    from yasinai.providers import LocalProvider, ProviderCapability, build_default_registry
+    from yasinai.providers import (
+        LocalProvider,
+        ProviderCapability,
+        build_default_registry,
+    )
+    from yasinai.services import GenerationService, KnowledgeService, RagService
 
     assert GenerationRequest and RagRequest
     assert GenerationService and KnowledgeService and RagService

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -15,7 +15,6 @@ from yasinai.providers.base import (
 from yasinai.providers.registry import ProviderRegistry, ProviderRegistryError
 from yasinai.providers.router import ProviderRouter, ProviderUnavailableError
 
-
 # ---------------------------------------------------------------------------
 # Fixtures — stub provider implementations
 # ---------------------------------------------------------------------------

--- a/tests/test_rag_service.py
+++ b/tests/test_rag_service.py
@@ -18,8 +18,8 @@ from yasinai.services import GenerationService, KnowledgeService, RagService
 def knowledge(tmp_path, monkeypatch):
     monkeypatch.setenv("YASINAI_MEMORY_PATH", str(tmp_path / "mem.db"))
     monkeypatch.setenv("YASINAI_VECTOR_PATH", str(tmp_path / "vectors.db"))
-    from knowledge_platform.memory import MemoryManager
     from knowledge_platform.graph import KnowledgeGraph
+    from knowledge_platform.memory import MemoryManager
     from knowledge_platform.semantic_search import Retriever
 
     return KnowledgeService(
@@ -114,6 +114,7 @@ def test_rag_prompt_includes_injected_source_without_dropping_it(rag, knowledge)
 
 def test_rag_build_prompt_flags_injection_phrase_via_logging(caplog):
     import logging as _logging
+
     from yasinai.contracts.knowledge import KnowledgeEntry
     from yasinai.contracts.rag import RagRequest
 
@@ -156,7 +157,7 @@ def test_rag_generation_failure_surfaces(knowledge):
 
 
 def test_service_import_surface():
-    from yasinai import services, contracts
+    from yasinai import contracts, services
 
     assert hasattr(services, "RagService")
     assert hasattr(contracts, "RagRequest")

--- a/tests/test_security_platform.py
+++ b/tests/test_security_platform.py
@@ -3,14 +3,13 @@ Unit Tests for YasinAI Security Platform.
 Covers Identity, Authentication, Authorization, Encryption, and Monitoring.
 """
 
-import time
 import pytest
-from security_platform.identity import IdentityManager
+
 from security_platform.auth import AuthManager
 from security_platform.authorization import PolicyEngine
 from security_platform.encryption import EncryptionEngine, SecretStore
-from security_platform.monitoring import AuditLogger, ThreatDetector, SecurityEvent
-
+from security_platform.identity import IdentityManager
+from security_platform.monitoring import AuditLogger, SecurityEvent, ThreatDetector
 
 # --- Identity Tests ---
 

--- a/yasinai/cli/main.py
+++ b/yasinai/cli/main.py
@@ -2,7 +2,8 @@ import argparse
 import json
 import logging
 import sys
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
+
 from yasinai.core.runtime import Runtime
 
 logger = logging.getLogger(__name__)
@@ -233,6 +234,7 @@ def handle_serve(args: argparse.Namespace) -> int:
     """
     import signal
     import time
+
     from yasinai.deployment.health_check import HealthCheck
 
     logger.debug("Executing CLI command: serve")
@@ -424,7 +426,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     if hasattr(args, "func"):
         # Propagate the top-level --json option to nested args if not present
         if args.json and not hasattr(args, "json"):
-            setattr(args, "json", True)
+            args.json = True
         exit_code: int = args.func(args)
         sys.exit(exit_code)
     else:

--- a/yasinai/contracts/__init__.py
+++ b/yasinai/contracts/__init__.py
@@ -10,36 +10,36 @@ Import from here, never from internal implementation modules.
 
 from yasinai.contracts.base import (
     CapabilityError,
+    CapabilityMetadata,
     CapabilityUnavailableError,
     ContractViolationError,
     ObservabilityContext,
-    CapabilityMetadata,
-)
-from yasinai.contracts.memory import (
-    MemoryRequest,
-    MemoryResponse,
-    MemoryEntry,
-    MemoryType,
-)
-from yasinai.contracts.knowledge import (
-    KnowledgeQuery,
-    KnowledgeResult,
-    KnowledgeEntry,
-    KnowledgeQueryType,
 )
 from yasinai.contracts.embedding import (
     EmbeddingRequest,
     EmbeddingResponse,
     EmbeddingVector,
 )
+from yasinai.contracts.generation import (
+    GenerationRequest,
+    GenerationResult,
+)
+from yasinai.contracts.knowledge import (
+    KnowledgeEntry,
+    KnowledgeQuery,
+    KnowledgeQueryType,
+    KnowledgeResult,
+)
+from yasinai.contracts.memory import (
+    MemoryEntry,
+    MemoryRequest,
+    MemoryResponse,
+    MemoryType,
+)
 from yasinai.contracts.plugin import (
     PluginContract,
     PluginInvokeRequest,
     PluginInvokeResponse,
-)
-from yasinai.contracts.generation import (
-    GenerationRequest,
-    GenerationResult,
 )
 from yasinai.contracts.rag import (
     RagRequest,

--- a/yasinai/core/config.py
+++ b/yasinai/core/config.py
@@ -1,6 +1,6 @@
-import os
 import json
 import logging
+import os
 from typing import Any, Dict, Optional
 
 # Setup local module logger

--- a/yasinai/deployment/__init__.py
+++ b/yasinai/deployment/__init__.py
@@ -3,9 +3,9 @@ YasinAI Deployment System.
 Provides installer, docker support, packaging and health checks.
 """
 
-from yasinai.deployment.installer import Installer
 from yasinai.deployment.docker_manager import DockerManager
-from yasinai.deployment.package_builder import PackageBuilder
 from yasinai.deployment.health_check import HealthCheck
+from yasinai.deployment.installer import Installer
+from yasinai.deployment.package_builder import PackageBuilder
 
-__all__ = ["Installer", "DockerManager", "PackageBuilder", "HealthCheck"]
+__all__ = ["DockerManager", "HealthCheck", "Installer", "PackageBuilder"]

--- a/yasinai/deployment/docker_manager.py
+++ b/yasinai/deployment/docker_manager.py
@@ -184,7 +184,7 @@ class DockerManager:
                 f.write(content)
             logger.info("Wrote %s at: %s", label, path)
             return True
-        except IOError as e:
+        except OSError as e:
             logger.error("Failed to write %s: %s", label, e, exc_info=True)
             return False
 

--- a/yasinai/deployment/health_check.py
+++ b/yasinai/deployment/health_check.py
@@ -59,7 +59,7 @@ class HealthCheck:
             logger.error(f"Core Runtime health check: FAILED: {e}", exc_info=True)
             return {
                 "success": False,
-                "message": f"Core Runtime verification failed: {str(e)}",
+                "message": f"Core Runtime verification failed: {e!s}",
                 "details": {}
             }
 
@@ -88,7 +88,7 @@ class HealthCheck:
             logger.error(f"CLI health check: FAILED: {e}", exc_info=True)
             return {
                 "success": False,
-                "message": f"CLI verification failed: {str(e)}",
+                "message": f"CLI verification failed: {e!s}",
                 "subcommands_found": []
             }
 
@@ -98,8 +98,8 @@ class HealthCheck:
         """
         logger.debug("Checking Security Platform health...")
         try:
-            from security_platform.identity import IdentityManager
             from security_platform.encryption import EncryptionEngine
+            from security_platform.identity import IdentityManager
 
             id_mgr = IdentityManager()
             # Roles need to be created before assigning them
@@ -123,7 +123,7 @@ class HealthCheck:
             logger.error(f"Security Platform health check: FAILED: {e}", exc_info=True)
             return {
                 "success": False,
-                "message": f"Security Platform verification failed: {str(e)}",
+                "message": f"Security Platform verification failed: {e!s}",
                 "identity_ok": False,
                 "encryption_ok": False
             }
@@ -157,7 +157,7 @@ class HealthCheck:
             logger.error(f"Knowledge Platform health check: FAILED: {e}", exc_info=True)
             return {
                 "success": False,
-                "message": f"Knowledge Platform verification failed: {str(e)}",
+                "message": f"Knowledge Platform verification failed: {e!s}",
                 "memory_ok": False,
                 "search_ok": False
             }

--- a/yasinai/deployment/installer.py
+++ b/yasinai/deployment/installer.py
@@ -3,10 +3,10 @@ Installer for YasinAI Deployment System.
 Handles local setup, directory creation, configuration template setup, and environment verification.
 """
 
+import json
 import logging
 import os
 import sys
-import json
 from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
@@ -106,7 +106,7 @@ class Installer:
                     json.dump(default_config, f, indent=4)
                 config_created = True
                 logger.info(f"Created default configuration template at: {config_path}")
-            except IOError as e:
+            except OSError as e:
                 logger.error(f"Failed to create configuration file template at '{config_path}': {e}", exc_info=True)
 
         logger.info("YasinAI local installation successfully completed.")

--- a/yasinai/integration/__init__.py
+++ b/yasinai/integration/__init__.py
@@ -7,17 +7,17 @@ These modules show how external Yasin products should consume Yasin-AI
 """
 
 from yasinai.integration.agent_client import YasinAgentClient
-from yasinai.integration.hub_client import YasinHubClient
 from yasinai.integration.cli_client import YasinCLIClient
-from yasinai.integration.relay_client import YasinRelayClient
 from yasinai.integration.feed_client import YasinFeedClient
+from yasinai.integration.hub_client import YasinHubClient
 from yasinai.integration.press_client import YasinPressClient
+from yasinai.integration.relay_client import YasinRelayClient
 
 __all__ = [
     "YasinAgentClient",
-    "YasinHubClient",
     "YasinCLIClient",
-    "YasinRelayClient",
     "YasinFeedClient",
+    "YasinHubClient",
     "YasinPressClient",
+    "YasinRelayClient",
 ]

--- a/yasinai/integration/hub_client.py
+++ b/yasinai/integration/hub_client.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 from observability.metrics import MetricsRegistry
-
 from yasinai.contracts.generation import GenerationRequest, GenerationResult
 from yasinai.contracts.knowledge import (
     KnowledgeQuery,

--- a/yasinai/integration/relay_client.py
+++ b/yasinai/integration/relay_client.py
@@ -6,7 +6,7 @@ enrichment (generation / RAG) without importing internal platforms.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Optional
 
 from yasinai.contracts.generation import GenerationRequest, GenerationResult
 from yasinai.contracts.rag import RagRequest, RagResult

--- a/yasinai/providers/__init__.py
+++ b/yasinai/providers/__init__.py
@@ -15,33 +15,33 @@ Usage:
     from yasinai.providers.base import GenerationRequest, GenerationResponse
 """
 
+from yasinai.providers.anthropic_provider import AnthropicProvider
 from yasinai.providers.base import (
-    ProviderBase,
-    ProviderCapability,
-    ProviderInfo,
     GenerationRequest,
     GenerationResponse,
+    ProviderBase,
+    ProviderCapability,
     ProviderError,
+    ProviderInfo,
 )
-from yasinai.providers.registry import ProviderRegistry
-from yasinai.providers.router import ProviderRouter
 from yasinai.providers.factory import build_default_registry, register_default_providers
 from yasinai.providers.local_provider import LocalProvider
 from yasinai.providers.openai_provider import OpenAIProvider
-from yasinai.providers.anthropic_provider import AnthropicProvider
+from yasinai.providers.registry import ProviderRegistry
+from yasinai.providers.router import ProviderRouter
 
 __all__ = [
-    "ProviderBase",
-    "ProviderCapability",
-    "ProviderInfo",
+    "AnthropicProvider",
     "GenerationRequest",
     "GenerationResponse",
-    "ProviderError",
-    "ProviderRegistry",
-    "ProviderRouter",
     "LocalProvider",
     "OpenAIProvider",
-    "AnthropicProvider",
+    "ProviderBase",
+    "ProviderCapability",
+    "ProviderError",
+    "ProviderInfo",
+    "ProviderRegistry",
+    "ProviderRouter",
     "build_default_registry",
     "register_default_providers",
 ]

--- a/yasinai/providers/anthropic_provider.py
+++ b/yasinai/providers/anthropic_provider.py
@@ -136,7 +136,7 @@ class AnthropicProvider(ProviderBase):
             payload = self._transport(url, headers, body)
         except ProviderError:
             raise
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.error("Anthropic transport error: %s", exc)
             raise ProviderError(
                 "anthropic",

--- a/yasinai/providers/openai_provider.py
+++ b/yasinai/providers/openai_provider.py
@@ -142,7 +142,7 @@ class OpenAIProvider(ProviderBase):
             payload = self._transport(url, headers, body)
         except ProviderError:
             raise
-        except Exception as exc:  # noqa: BLE001 — boundary: never leak transport errors
+        except Exception as exc:
             logger.error("OpenAI transport error: %s", exc)
             raise ProviderError(
                 "openai",

--- a/yasinai/providers/registry.py
+++ b/yasinai/providers/registry.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 from threading import Lock
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, List, Optional
 
 from yasinai.providers.base import ProviderBase, ProviderCapability, ProviderInfo
 

--- a/yasinai/services/__init__.py
+++ b/yasinai/services/__init__.py
@@ -8,12 +8,12 @@ Consumers may import from here or from contracts; they must not import
 internal packages directly.
 """
 
-from yasinai.services.knowledge_service import KnowledgeService
 from yasinai.services.generation_service import GenerationService
+from yasinai.services.knowledge_service import KnowledgeService
 from yasinai.services.rag_service import RagService
 
 __all__ = [
-    "KnowledgeService",
     "GenerationService",
+    "KnowledgeService",
     "RagService",
 ]

--- a/yasinai/services/generation_service.py
+++ b/yasinai/services/generation_service.py
@@ -13,6 +13,8 @@ from yasinai.contracts.base import CapabilityMetadata
 from yasinai.contracts.generation import GenerationRequest, GenerationResult
 from yasinai.providers.base import (
     GenerationRequest as ProviderGenerationRequest,
+)
+from yasinai.providers.base import (
     ProviderBase,
     ProviderCapability,
     ProviderError,
@@ -114,7 +116,7 @@ class GenerationService:
                         candidate.info.name, exc.retryable, exc,
                     )
                     break
-                except Exception as exc:  # noqa: BLE001 — facade must not leak
+                except Exception as exc:
                     logger.exception("GenerationService.generate failed")
                     return GenerationResult(success=False, error=str(exc), meta=meta)
 

--- a/yasinai/services/knowledge_service.py
+++ b/yasinai/services/knowledge_service.py
@@ -26,10 +26,10 @@ from yasinai.contracts.memory import (
 logger = logging.getLogger(__name__)
 
 # Internal imports — only allowed inside the service layer
-from knowledge_platform.memory import MemoryManager
 from knowledge_platform.graph import KnowledgeGraph
-from knowledge_platform.semantic_search import Retriever
+from knowledge_platform.memory import MemoryManager
 from knowledge_platform.reasoning import KnowledgeReasoner
+from knowledge_platform.semantic_search import Retriever
 
 
 class KnowledgeService:
@@ -76,7 +76,7 @@ class KnowledgeService:
                 error=f"Unsupported memory operation: {op}",
                 meta=meta,
             )
-        except Exception as exc:  # noqa: BLE001 — facade must not leak internals
+        except Exception as exc:
             logger.exception("KnowledgeService.memory failed")
             return MemoryResponse(success=False, error=str(exc), meta=meta)
 
@@ -202,7 +202,7 @@ class KnowledgeService:
                 error=f"Unsupported query_type: {qt}",
                 meta=meta,
             )
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.exception("KnowledgeService.query failed")
             return KnowledgeResult(success=False, error=str(exc), meta=meta)
 

--- a/yasinai/services/rag_service.py
+++ b/yasinai/services/rag_service.py
@@ -92,7 +92,7 @@ class RagService:
                     provider=gen.provider,
                 ),
             )
-        except Exception as exc:  # noqa: BLE001 — facade boundary
+        except Exception as exc:
             logger.exception("RagService.run failed")
             return RagResult(success=False, error=str(exc), meta=meta)
 


### PR DESCRIPTION
Fixes #115.

## Changes
- Added `ruff==0.16.3` (pinned) as a new `lint` optional-dependency extra, plus `[tool.ruff]` config (`target-version = "py39"`, `line-length = 120`).
- Added a new `lint` CI job running `ruff check . --output-format=github` (inline PR annotations).
- Ran `ruff check . --fix` (safe fixes only, no `--unsafe-fixes`) — resolved 105 violations, mostly unused imports and import ordering. Full test suite verified green after.

## Baseline decision
Found 594 remaining violations after safe auto-fix, almost entirely legacy typing style (`UP006`/`UP045`/`UP035`/`FA100` — `List`/`Dict`/`Optional` vs modern `list`/`dict`/`X | None` syntax) plus a handful of others (`G201`, `F841`, `BLE001`, `SIM117`, `RUF012`, `SIM102`, `PLW1510`). Fixing these safely needs `--unsafe-fixes` or manual per-case review — too large for this issue's scope.

- Opened follow-up issue **#116** tracking the full backlog with a category breakdown.
- The lint job runs with `continue-on-error: true` until #116 is cleared, so CI reports the baseline without blocking builds. The comment in `ci.yml` links to #116 and says to flip it once resolved.

## mypy
Not added — type hint coverage across the codebase is partial/inconsistent, so a meaningful type-check pass isn't feasible until the typing-modernization work in #116 lands. Revisit after.

## Verification
Full suite: 296 passed (no behavior changes — only import cleanup + CI config).
