### PR TITLE
fix: clear Ruff lint backlog and make CI lint blocking (#116)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           if-no-files-found: ignore
 
   lint:
-    name: Lint (Ruff, non-blocking)
+    name: Lint (Ruff)
     runs-on: ubuntu-latest
 
     steps:
@@ -69,12 +69,7 @@ jobs:
         run: python -m pip install --upgrade pip && python -m pip install -e ".[lint]"
 
       - name: Run Ruff
-        # Non-blocking: 594 pre-existing violations (mostly legacy typing
-        # style) are tracked in issue #116, not fixed here. This step
-        # reports the current baseline in CI output without failing the
-        # build. Flip continue-on-error to false once the backlog is
-        # cleared (see #116).
-        continue-on-error: true
+        # Blocking gate after #116 cleared the pre-existing Ruff backlog.
         run: ruff check . --output-format=github
 
   security:

--- a/api_service/app.py
+++ b/api_service/app.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable
 
 from .errors import APIError, ValidationError
 from .models import HealthResponse, ServiceResponse
@@ -21,7 +21,7 @@ Handler = Callable[[Mapping[str, Any]], Mapping[str, Any]]
 class APIService:
     name: str = "yasinai"
     version: str = "1.1.2"
-    _routes: Optional[Dict[str, Handler]] = None
+    _routes: dict[str, Handler] | None = None
 
     def __post_init__(self) -> None:
         self._routes = dict(self._routes or {})
@@ -39,7 +39,7 @@ class APIService:
     def health(self) -> HealthResponse:
         return HealthResponse("ok", self.name, self.version)
 
-    def dispatch(self, method: str, path: str, payload: Optional[Mapping[str, Any]] = None) -> ServiceResponse:
+    def dispatch(self, method: str, path: str, payload: Mapping[str, Any] | None = None) -> ServiceResponse:
         key = f"{method.upper().strip()} {self._normalize_path(path)}"
         if key == "GET /health":
             return ServiceResponse(200, self.health().as_dict())
@@ -56,7 +56,7 @@ class APIService:
             # for debugging; never leak exception text or a traceback into
             # the response body — same "don't expose internals" principle
             # applied to provider error handling elsewhere in this codebase.
-            logger.error("Unhandled exception in handler for %s", key, exc_info=True)
+            logger.exception("Unhandled exception in handler for %s", key)
             return ServiceResponse(500, {"error": "internal server error"})
         return ServiceResponse(200, result)
 

--- a/api_service/models.py
+++ b/api_service/models.py
@@ -1,13 +1,13 @@
 """Small immutable response models shared by API transports."""
 
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any
 
 
 @dataclass(frozen=True)
 class ServiceResponse:
     status: int
-    data: Dict[str, Any] = field(default_factory=dict)
+    data: dict[str, Any] = field(default_factory=dict)
 
 @dataclass(frozen=True)
 class HealthResponse:
@@ -15,5 +15,5 @@ class HealthResponse:
     service: str
     version: str
 
-    def as_dict(self) -> Dict[str, str]:
+    def as_dict(self) -> dict[str, str]:
         return {"status": self.status, "service": self.service, "version": self.version}

--- a/developer_platform/agent.py
+++ b/developer_platform/agent.py
@@ -2,9 +2,9 @@
 Agent SDK for YasinAI Developer Platform.
 Manages AI agent definitions, task execution, and agent lifecycle.
 """
+from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class AgentSDK:
     """
 
     def __init__(self) -> None:
-        self._agents: Dict[str, Agent] = {}
+        self._agents: dict[str, Agent] = {}
 
     def create_agent(
         self,
@@ -87,7 +87,7 @@ class AgentSDK:
         logger.info(f"Successfully registered agent: '{name}'")
         return agent
 
-    def get_agent(self, name: str) -> Optional[Agent]:
+    def get_agent(self, name: str) -> Agent | None:
         """
         Retrieve an agent by name.
         """
@@ -104,7 +104,7 @@ class AgentSDK:
         logger.warning(f"Attempted to delete non-existent agent: '{name}'")
         return False
 
-    def list_agents(self) -> List[Agent]:
+    def list_agents(self) -> list[Agent]:
         """
         List all registered agents.
         """

--- a/developer_platform/app.py
+++ b/developer_platform/app.py
@@ -2,9 +2,10 @@
 Application SDK for YasinAI Developer Platform.
 Provides building blocks for creating AI-powered applications.
 """
+from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from developer_platform.agent import Agent
 from developer_platform.plugin import Plugin
@@ -18,11 +19,11 @@ class AIApplication:
     Represents an end-to-end AI Application composed of agents and plugins.
     """
 
-    def __init__(self, name: str, config: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, name: str, config: dict[str, Any] | None = None) -> None:
         self.name: str = name
-        self.config: Dict[str, Any] = config or {}
-        self._agents: Dict[str, Agent] = {}
-        self._plugins: Dict[str, Plugin] = {}
+        self.config: dict[str, Any] = config or {}
+        self._agents: dict[str, Agent] = {}
+        self._plugins: dict[str, Plugin] = {}
 
     def add_agent(self, agent: Agent) -> None:
         """
@@ -58,25 +59,25 @@ class AIApplication:
         self._plugins[plugin.name] = plugin
         logger.info(f"Plugin '{plugin.name}' added to application '{self.name}'.")
 
-    def list_agents(self) -> List[Agent]:
+    def list_agents(self) -> list[Agent]:
         """
         List all agents assigned to the application.
         """
         return list(self._agents.values())
 
-    def list_plugins(self) -> List[Plugin]:
+    def list_plugins(self) -> list[Plugin]:
         """
         List all plugins assigned to the application.
         """
         return list(self._plugins.values())
 
-    def run(self, input_query: str) -> Dict[str, Any]:
+    def run(self, input_query: str) -> dict[str, Any]:
         """
         Run the application pipeline, invoking agents and plugins to answer the input query.
         """
         logger.info(f"Running AI Application '{self.name}' with query: '{input_query}'")
-        steps_executed: List[str] = []
-        result_payload: Dict[str, Any] = {}
+        steps_executed: list[str] = []
+        result_payload: dict[str, Any] = {}
 
         # Simulating workflow execution:
         # 1. Initialize and execute plugins if any
@@ -88,7 +89,7 @@ class AIApplication:
             result_payload[f"plugin_{name}"] = plugin_res
 
         # 2. Run agents to answer query
-        agent_responses: List[str] = []
+        agent_responses: list[str] = []
         for name, agent in self._agents.items():
             if agent.status != "active":
                 agent.start()
@@ -117,9 +118,9 @@ class AppSDK:
     """
 
     def __init__(self) -> None:
-        self._applications: Dict[str, AIApplication] = {}
+        self._applications: dict[str, AIApplication] = {}
 
-    def create_application(self, name: str, config: Optional[Dict[str, Any]] = None) -> AIApplication:
+    def create_application(self, name: str, config: dict[str, Any] | None = None) -> AIApplication:
         """
         Create and register a new AI Application.
         """
@@ -131,7 +132,7 @@ class AppSDK:
         logger.info(f"Successfully registered AI Application: '{name}'")
         return app
 
-    def get_application(self, name: str) -> Optional[AIApplication]:
+    def get_application(self, name: str) -> AIApplication | None:
         """
         Get a registered AI Application.
         """
@@ -148,7 +149,7 @@ class AppSDK:
         logger.warning(f"Attempted to delete non-existent AI Application: '{name}'")
         return False
 
-    def list_applications(self) -> List[AIApplication]:
+    def list_applications(self) -> list[AIApplication]:
         """
         List all registered AI Applications.
         """

--- a/developer_platform/debugger.py
+++ b/developer_platform/debugger.py
@@ -2,9 +2,10 @@
 Debugging and Execution Tracer for YasinAI Developer Platform.
 Tracks agent steps, inputs, outputs, and status.
 """
+from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -15,8 +16,8 @@ class Debugger:
     """
 
     def __init__(self) -> None:
-        self.current_agent: Optional[str] = None
-        self.logs: List[Dict[str, Any]] = []
+        self.current_agent: str | None = None
+        self.logs: list[dict[str, Any]] = []
 
     def start_session(self, agent_name: str) -> None:
         """
@@ -42,7 +43,7 @@ class Debugger:
             "output": output_data
         })
 
-    def get_session_logs(self) -> List[Dict[str, Any]]:
+    def get_session_logs(self) -> list[dict[str, Any]]:
         """
         Retrieve all execution logs recorded in the current session.
         """

--- a/developer_platform/extension.py
+++ b/developer_platform/extension.py
@@ -2,9 +2,10 @@
 Extension API for YasinAI Developer Platform.
 Allows third-party systems to expose custom capabilities or hooks.
 """
+from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +16,7 @@ class ExtensionAPI:
     """
 
     def __init__(self) -> None:
-        self._extensions: Dict[str, Dict[str, Any]] = {}
+        self._extensions: dict[str, dict[str, Any]] = {}
 
     def register_extension(self, name: str, ext_type: str, handler: Any) -> None:
         """
@@ -32,7 +33,7 @@ class ExtensionAPI:
         }
         logger.info(f"Successfully registered developer extension: '{name}' of type '{ext_type}'")
 
-    def get_extension(self, name: str) -> Optional[Dict[str, Any]]:
+    def get_extension(self, name: str) -> dict[str, Any] | None:
         """
         Retrieve a registered extension dictionary.
         """
@@ -64,7 +65,7 @@ class ExtensionAPI:
         logger.warning(f"Attempted to unregister non-existent extension: '{name}'")
         return False
 
-    def list_extensions(self) -> List[Dict[str, Any]]:
+    def list_extensions(self) -> list[dict[str, Any]]:
         """
         List all registered developer extensions.
         """

--- a/developer_platform/plugin.py
+++ b/developer_platform/plugin.py
@@ -2,9 +2,10 @@
 Plugin SDK for YasinAI Developer Platform.
 Manages external extensions and third-party modules.
 """
+from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from developer_platform.sdk import PluginTrustError
 
@@ -69,7 +70,7 @@ class PluginSDK:
     """
 
     def __init__(self, *, allow_untrusted: bool = False) -> None:
-        self._plugins: Dict[str, Plugin] = {}
+        self._plugins: dict[str, Plugin] = {}
         self.allow_untrusted = allow_untrusted
 
     def register_plugin(self, plugin: Plugin) -> None:
@@ -98,7 +99,7 @@ class PluginSDK:
         self._plugins[plugin.name] = plugin
         logger.info(f"Successfully registered plugin: '{plugin.name}'")
 
-    def get_plugin(self, name: str) -> Optional[Plugin]:
+    def get_plugin(self, name: str) -> Plugin | None:
         """
         Look up a registered plugin by name.
         """
@@ -128,7 +129,7 @@ class PluginSDK:
         logger.warning(f"Failed to disable plugin: '{name}' not found.")
         return False
 
-    def list_plugins(self) -> List[Plugin]:
+    def list_plugins(self) -> list[Plugin]:
         """
         List all registered plugins.
         """

--- a/developer_platform/profiler.py
+++ b/developer_platform/profiler.py
@@ -5,7 +5,7 @@ Measures execution times and resource utilization metrics.
 
 import logging
 import time
-from typing import Any, Dict
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -16,8 +16,8 @@ class Profiler:
     """
 
     def __init__(self) -> None:
-        self.start_times: Dict[str, float] = {}
-        self.profiles: Dict[str, float] = {}
+        self.start_times: dict[str, float] = {}
+        self.profiles: dict[str, float] = {}
 
     def start_profile(self, operation_name: str) -> None:
         """
@@ -40,7 +40,7 @@ class Profiler:
         logger.info(f"Operation '{operation_name}' profiled in {elapsed:.6f} seconds.")
         return elapsed
 
-    def get_profile_report(self) -> Dict[str, Any]:
+    def get_profile_report(self) -> dict[str, Any]:
         """
         Generate a performance report of all profiled operations.
         """

--- a/developer_platform/sdk.py
+++ b/developer_platform/sdk.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable
 
 
 class SDKError(Exception):
@@ -31,7 +31,7 @@ class PluginSpec:
     handler: Callable[..., Any]
     version: str = "1.0.0"
     description: str = ""
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
     trusted: bool = True
 
 
@@ -43,7 +43,7 @@ class PluginRegistry:
     """
 
     def __init__(self, *, allow_untrusted: bool = False) -> None:
-        self._plugins: Dict[str, PluginSpec] = {}
+        self._plugins: dict[str, PluginSpec] = {}
         self.allow_untrusted = allow_untrusted
 
     def register(self, plugin: PluginSpec) -> PluginSpec:
@@ -63,7 +63,7 @@ class PluginRegistry:
     def unregister(self, name: str) -> bool:
         return self._plugins.pop(name, None) is not None
 
-    def get(self, name: str) -> Optional[PluginSpec]:
+    def get(self, name: str) -> PluginSpec | None:
         return self._plugins.get(name)
 
     def list(self) -> Iterable[PluginSpec]:
@@ -81,7 +81,7 @@ def plugin(
     *,
     version: str = "1.0.0",
     description: str = "",
-    metadata: Optional[Dict[str, Any]] = None,
+    metadata: dict[str, Any] | None = None,
     trusted: bool = True,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Declare plugin metadata without coupling the handler to the registry."""

--- a/knowledge_platform/context.py
+++ b/knowledge_platform/context.py
@@ -4,7 +4,6 @@ Implements ConversationMemory, ContextBuilder, and ReasoningEngine.
 """
 
 import logging
-from typing import Dict, List
 
 logger = logging.getLogger(__name__)
 
@@ -15,20 +14,20 @@ class ConversationMemory:
     """
 
     def __init__(self) -> None:
-        self.history: List[Dict[str, str]] = []
+        self.history: list[dict[str, str]] = []
 
     def add_message(self, role: str, content: str) -> None:
         """Add a turn to conversation history."""
         logger.debug(f"Adding message to conversation history: role={role}")
         self.history.append({"role": role, "content": content})
 
-    def get_history(self) -> List[Dict[str, str]]:
+    def get_history(self) -> list[dict[str, str]]:
         """Retrieve full message history."""
         return self.history
 
     def get_formatted_history(self) -> str:
         """Get formatted chat history as string."""
-        formatted: List[str] = []
+        formatted: list[str] = []
         for msg in self.history:
             role_label = msg["role"].capitalize()
             formatted.append(f"{role_label}: {msg['content']}")
@@ -49,12 +48,12 @@ class ContextBuilder:
     def __init__(self) -> None:
         pass
 
-    def build_context(self, user_input: str, chat_history: List[Dict[str, str]], retrieved_knowledge: List[str]) -> str:
+    def build_context(self, user_input: str, chat_history: list[dict[str, str]], retrieved_knowledge: list[str]) -> str:
         """
         Synthesize the final structured context prompt.
         """
         logger.debug(f"Synthesizing structured prompt context for input='{user_input}'...")
-        sections: List[str] = []
+        sections: list[str] = []
 
         # 1. System Prompt / Instructions
         sections.append("System Prompt: You are a helpful AI Assistant. Synthesize responses based on the provided context, rules, and conversation history.")
@@ -86,7 +85,7 @@ class ReasoningEngine:
     def __init__(self) -> None:
         pass
 
-    def evaluate_and_refine(self, raw_context: str, rules_applied: List[str]) -> str:
+    def evaluate_and_refine(self, raw_context: str, rules_applied: list[str]) -> str:
         """
         Evaluate context against specific system rules and append compliance instructions.
         """

--- a/knowledge_platform/entity.py
+++ b/knowledge_platform/entity.py
@@ -1,8 +1,9 @@
 """
 Entity component for YasinAI Knowledge Graph.
 """
+from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 
 class Entity:
@@ -10,10 +11,10 @@ class Entity:
     Represents a semantic concept or instance in the Knowledge Graph.
     """
 
-    def __init__(self, name: str, entity_type: str = "Concept", properties: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, name: str, entity_type: str = "Concept", properties: dict[str, Any] | None = None) -> None:
         self.name: str = name
         self.entity_type: str = entity_type
-        self.properties: Dict[str, Any] = properties or {}
+        self.properties: dict[str, Any] = properties or {}
 
     def get_property(self, key: str, default: Any = None) -> Any:
         """Get property by key."""

--- a/knowledge_platform/graph.py
+++ b/knowledge_platform/graph.py
@@ -1,9 +1,9 @@
 """
 Knowledge Graph coordinator for YasinAI Knowledge Platform.
 """
+from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional, Tuple
 
 from knowledge_platform.entity import Entity
 from knowledge_platform.query_engine import QueryEngine
@@ -20,12 +20,12 @@ class KnowledgeGraph:
     """
 
     def __init__(self) -> None:
-        self.entities: Dict[str, Entity] = {}
-        self.relations: Dict[str, Relation] = {}
+        self.entities: dict[str, Entity] = {}
+        self.relations: dict[str, Relation] = {}
         self.triple_store: TripleStore = TripleStore()
         self.query_engine: QueryEngine = QueryEngine(self.triple_store)
 
-    def add_entity(self, name: str, entity_type: str = "Concept", properties: Optional[dict] = None) -> Entity:
+    def add_entity(self, name: str, entity_type: str = "Concept", properties: dict | None = None) -> Entity:
         """Create and add an entity to the graph."""
         logger.debug(f"KnowledgeGraph: Adding entity '{name}' of type '{entity_type}'")
         if name in self.entities:
@@ -38,7 +38,7 @@ class KnowledgeGraph:
         self.entities[name] = entity
         return entity
 
-    def get_entity(self, name: str) -> Optional[Entity]:
+    def get_entity(self, name: str) -> Entity | None:
         """Look up an entity by name."""
         return self.entities.get(name)
 
@@ -59,7 +59,7 @@ class KnowledgeGraph:
         logger.warning(f"KnowledgeGraph: Attempted to delete non-existent entity '{name}'")
         return False
 
-    def add_relation(self, name: str, description: str = "", properties: Optional[dict] = None) -> Relation:
+    def add_relation(self, name: str, description: str = "", properties: dict | None = None) -> Relation:
         """Create and register a relation definition."""
         logger.debug(f"KnowledgeGraph: Registering relation '{name}'")
         if name in self.relations:
@@ -72,7 +72,7 @@ class KnowledgeGraph:
         self.relations[name] = relation
         return relation
 
-    def get_relation(self, name: str) -> Optional[Relation]:
+    def get_relation(self, name: str) -> Relation | None:
         """Look up a relation definition."""
         return self.relations.get(name)
 
@@ -88,11 +88,11 @@ class KnowledgeGraph:
 
         self.triple_store.add_triple(subject, predicate, obj)
 
-    def query(self, subject: Optional[str] = None, predicate: Optional[str] = None, obj: Optional[str] = None) -> List[Tuple[str, str, str]]:
+    def query(self, subject: str | None = None, predicate: str | None = None, obj: str | None = None) -> list[tuple[str, str, str]]:
         """Query stored triples."""
         return self.triple_store.query_triples(subject, predicate, obj)
 
-    def find_path(self, start: str, end: str, max_depth: int = 3) -> Optional[List[Tuple[str, str]]]:
+    def find_path(self, start: str, end: str, max_depth: int = 3) -> list[tuple[str, str]] | None:
         """Find a path between two entities."""
         return self.query_engine.find_path(start, end, max_depth)
 

--- a/knowledge_platform/memory.py
+++ b/knowledge_platform/memory.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional, Protocol
+from typing import Any, Protocol
 
 from knowledge_platform.memory_store import SQLiteMemoryStore
 
@@ -19,10 +19,10 @@ logger = logging.getLogger(__name__)
 class LongTermStore(Protocol):
     """Storage contract used by long-term memory."""
 
-    def store(self, key: str, content: Any, timestamp: float, metadata: Dict[str, Any]) -> Dict[str, Any]: ...
-    def retrieve(self, key: str) -> Optional[Dict[str, Any]]: ...
+    def store(self, key: str, content: Any, timestamp: float, metadata: dict[str, Any]) -> dict[str, Any]: ...
+    def retrieve(self, key: str) -> dict[str, Any] | None: ...
     def delete(self, key: str) -> bool: ...
-    def list_all(self) -> List[Dict[str, Any]]: ...
+    def list_all(self) -> list[dict[str, Any]]: ...
     def clear(self) -> None: ...
 
 
@@ -33,16 +33,16 @@ class ShortTermMemory:
         if capacity <= 0:
             raise ValueError("capacity must be greater than zero")
         self.capacity = capacity
-        self.memory: List[Dict[str, Any]] = []
+        self.memory: list[dict[str, Any]] = []
 
-    def store(self, content: Any, metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def store(self, content: Any, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
         if len(self.memory) >= self.capacity:
             self.memory.pop(0)
         entry = {"content": content, "timestamp": time.time(), "metadata": metadata or {}}
         self.memory.append(entry)
         return entry
 
-    def retrieve(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+    def retrieve(self, limit: int | None = None) -> list[dict[str, Any]]:
         sorted_mem = sorted(self.memory, key=lambda x: x["timestamp"], reverse=True)
         return sorted_mem[:limit] if limit is not None else sorted_mem
 
@@ -53,20 +53,20 @@ class ShortTermMemory:
 class LongTermMemory:
     """Persistent long-term memory using a pluggable store (SQLite by default)."""
 
-    def __init__(self, store: Optional[LongTermStore] = None, path: Optional[str] = None) -> None:
+    def __init__(self, store: LongTermStore | None = None, path: str | None = None) -> None:
         default_path = os.environ.get("YASINAI_MEMORY_PATH", "~/.yasinai/memory.db")
         self._store: LongTermStore = store or SQLiteMemoryStore(path or default_path)
 
-    def store(self, key: str, content: Any, metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def store(self, key: str, content: Any, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
         return self._store.store(key, content, time.time(), metadata or {})
 
-    def retrieve(self, key: str) -> Optional[Dict[str, Any]]:
+    def retrieve(self, key: str) -> dict[str, Any] | None:
         return self._store.retrieve(key)
 
     def delete(self, key: str) -> bool:
         return self._store.delete(key)
 
-    def list_all(self) -> List[Dict[str, Any]]:
+    def list_all(self) -> list[dict[str, Any]]:
         return self._store.list_all()
 
     def clear(self) -> None:
@@ -81,26 +81,26 @@ class LongTermMemory:
 class MemoryManager:
     """Orchestrates short-term and durable long-term memory."""
 
-    def __init__(self, short_term: Optional[ShortTermMemory] = None, long_term: Optional[LongTermMemory] = None) -> None:
+    def __init__(self, short_term: ShortTermMemory | None = None, long_term: LongTermMemory | None = None) -> None:
         self.short_term = short_term or ShortTermMemory()
         self.long_term = long_term or LongTermMemory()
 
-    def add_short_term(self, content: Any, metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def add_short_term(self, content: Any, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
         return self.short_term.store(content, metadata)
 
-    def add_long_term(self, key: str, content: Any, metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def add_long_term(self, key: str, content: Any, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
         return self.long_term.store(key, content, metadata)
 
-    def get_short_term(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+    def get_short_term(self, limit: int | None = None) -> list[dict[str, Any]]:
         return self.short_term.retrieve(limit)
 
-    def get_long_term(self, key: str) -> Optional[Dict[str, Any]]:
+    def get_long_term(self, key: str) -> dict[str, Any] | None:
         return self.long_term.retrieve(key)
 
     def delete_long_term(self, key: str) -> bool:
         return self.long_term.delete(key)
 
-    def consolidate_short_to_long(self, key: str, index: int, metadata: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+    def consolidate_short_to_long(self, key: str, index: int, metadata: dict[str, Any] | None = None) -> dict[str, Any] | None:
         short_memories = self.short_term.retrieve()
         if 0 <= index < len(short_memories):
             entry = short_memories[index]

--- a/knowledge_platform/memory_store.py
+++ b/knowledge_platform/memory_store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 class SQLiteMemoryStore:
@@ -32,7 +32,7 @@ class SQLiteMemoryStore:
         )
         self._connection.commit()
 
-    def store(self, key: str, content: Any, timestamp: float, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    def store(self, key: str, content: Any, timestamp: float, metadata: dict[str, Any]) -> dict[str, Any]:
         payload = json.dumps(content, ensure_ascii=False, default=str)
         metadata_json = json.dumps(metadata, ensure_ascii=False, default=str)
         self._connection.execute(
@@ -47,7 +47,7 @@ class SQLiteMemoryStore:
         self._connection.commit()
         return {"key": key, "content": content, "timestamp": timestamp, "metadata": metadata}
 
-    def retrieve(self, key: str) -> Optional[Dict[str, Any]]:
+    def retrieve(self, key: str) -> dict[str, Any] | None:
         row = self._connection.execute(
             "SELECT key, content, timestamp, metadata FROM memories WHERE key = ?", (key,)
         ).fetchone()
@@ -58,7 +58,7 @@ class SQLiteMemoryStore:
         self._connection.commit()
         return cursor.rowcount > 0
 
-    def list_all(self) -> List[Dict[str, Any]]:
+    def list_all(self) -> list[dict[str, Any]]:
         rows = self._connection.execute(
             "SELECT key, content, timestamp, metadata FROM memories ORDER BY timestamp DESC"
         ).fetchall()
@@ -72,7 +72,7 @@ class SQLiteMemoryStore:
         self._connection.close()
 
     @staticmethod
-    def _row_to_entry(row: sqlite3.Row) -> Dict[str, Any]:
+    def _row_to_entry(row: sqlite3.Row) -> dict[str, Any]:
         return {
             "key": row["key"],
             "content": json.loads(row["content"]),

--- a/knowledge_platform/query_engine.py
+++ b/knowledge_platform/query_engine.py
@@ -1,9 +1,9 @@
 """
 Query Engine for YasinAI Knowledge Graph.
 """
+from __future__ import annotations
 
 import logging
-from typing import List, Optional, Tuple
 
 from knowledge_platform.triple_store import TripleStore
 
@@ -18,13 +18,13 @@ class QueryEngine:
     def __init__(self, triple_store: TripleStore) -> None:
         self.triple_store: TripleStore = triple_store
 
-    def find_neighbors(self, entity_name: str) -> List[Tuple[str, str]]:
+    def find_neighbors(self, entity_name: str) -> list[tuple[str, str]]:
         """
         Find direct neighbors of an entity.
         Returns a list of tuples containing (relation_name, target_entity_name).
         """
         logger.debug(f"QueryEngine: Finding direct neighbors of entity: '{entity_name}'")
-        neighbors: List[Tuple[str, str]] = []
+        neighbors: list[tuple[str, str]] = []
 
         # Outgoing triples
         outgoing = self.triple_store.query_triples(subject=entity_name)
@@ -38,7 +38,7 @@ class QueryEngine:
 
         return neighbors
 
-    def find_path(self, start: str, end: str, max_depth: int = 3, visited: Optional[set] = None) -> Optional[List[Tuple[str, str]]]:
+    def find_path(self, start: str, end: str, max_depth: int = 3, visited: set | None = None) -> list[tuple[str, str]] | None:
         """
         Find a path of relations and entities between start and end entity names.
         Returns a list of (relation, entity) showing the path, or None if not found.

--- a/knowledge_platform/reasoning.py
+++ b/knowledge_platform/reasoning.py
@@ -4,7 +4,7 @@ Implements KnowledgeReasoner and RuleEngine.
 """
 
 import logging
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable
 
 from knowledge_platform.graph import KnowledgeGraph
 
@@ -19,17 +19,17 @@ class RuleEngine:
 
     def __init__(self) -> None:
         # Rules are tuples: (rule_name, condition_fn, action_fn)
-        self.rules: List[Tuple[str, Callable[[Any], bool], Callable[[Any], Any]]] = []
+        self.rules: list[tuple[str, Callable[[Any], bool], Callable[[Any], Any]]] = []
 
     def add_rule(self, name: str, condition: Callable[[Any], bool], action: Callable[[Any], Any]) -> None:
         """Register a logical rule."""
         logger.debug(f"Registering logical rule in RuleEngine: '{name}'")
         self.rules.append((name, condition, action))
 
-    def evaluate(self, facts: Any) -> List[Dict[str, Any]]:
+    def evaluate(self, facts: Any) -> list[dict[str, Any]]:
         """Evaluate all facts against rules, trigger actions and return results."""
         logger.debug("Evaluating facts against registered rules...")
-        triggered_results: List[Dict[str, Any]] = []
+        triggered_results: list[dict[str, Any]] = []
         for name, condition, action in self.rules:
             try:
                 if condition(facts):
@@ -39,8 +39,8 @@ class RuleEngine:
                         "rule_name": name,
                         "result": result
                     })
-            except Exception as e:
-                logger.error(f"Error evaluating rule '{name}': {e}", exc_info=True)
+            except Exception:
+                logger.exception("Error evaluating rule '{name}'")
         return triggered_results
 
 
@@ -53,14 +53,14 @@ class KnowledgeReasoner:
     def __init__(self, graph: KnowledgeGraph) -> None:
         self.graph: KnowledgeGraph = graph
 
-    def deduce_transitive_relations(self, start_entity: str, relation_name: str) -> List[str]:
+    def deduce_transitive_relations(self, start_entity: str, relation_name: str) -> list[str]:
         """
         Deduce transitive connections for a relation (e.g. A is_part_of B, B is_part_of C -> A is_part_of C).
         Returns list of all directly or indirectly connected entities.
         """
         logger.info(f"Deducing transitive relations for '{start_entity}' over relation '{relation_name}'")
-        connected: List[str] = []
-        queue: List[str] = [start_entity]
+        connected: list[str] = []
+        queue: list[str] = [start_entity]
         visited = {start_entity}
 
         while queue:
@@ -74,14 +74,14 @@ class KnowledgeReasoner:
         logger.debug(f"Transitive deduction results for '{start_entity}': {connected}")
         return connected
 
-    def deduce_symmetric_relations(self, relation_name: str, symmetric_relation_name: str) -> List[Tuple[str, str, str]]:
+    def deduce_symmetric_relations(self, relation_name: str, symmetric_relation_name: str) -> list[tuple[str, str, str]]:
         """
         For a symmetric relationship (e.g., if A is_partner_of B, then B is_partner_of A),
         find all implied relationships that are missing.
         Returns a list of deduced triples (subject, predicate, obj).
         """
         logger.info(f"Deducing symmetric relations for '{relation_name}' as symmetric to '{symmetric_relation_name}'")
-        deduced_triples: List[Tuple[str, str, str]] = []
+        deduced_triples: list[tuple[str, str, str]] = []
         all_triples = self.graph.query(predicate=relation_name)
         for s, p, o in all_triples:
             # Check if symmetric triple is already in graph

--- a/knowledge_platform/relation.py
+++ b/knowledge_platform/relation.py
@@ -1,8 +1,9 @@
 """
 Relation component for YasinAI Knowledge Graph.
 """
+from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 
 class Relation:
@@ -10,10 +11,10 @@ class Relation:
     Represents a semantic connection or relationship between entities in the Knowledge Graph.
     """
 
-    def __init__(self, name: str, description: str = "", properties: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, name: str, description: str = "", properties: dict[str, Any] | None = None) -> None:
         self.name: str = name
         self.description: str = description
-        self.properties: Dict[str, Any] = properties or {}
+        self.properties: dict[str, Any] = properties or {}
 
     def __repr__(self) -> str:
         return f"Relation(name={self.name!r})"

--- a/knowledge_platform/semantic_search.py
+++ b/knowledge_platform/semantic_search.py
@@ -11,7 +11,7 @@ import logging
 import math
 import os
 import re
-from typing import Any, Dict, List, Optional, Protocol
+from typing import Any, Protocol
 
 from knowledge_platform.vector_store import SQLiteVectorStore
 
@@ -19,8 +19,8 @@ logger = logging.getLogger(__name__)
 
 
 class VectorStoreProtocol(Protocol):
-    def store_vector(self, text_id: str, vector: List[float], metadata: Optional[Dict[str, Any]] = None) -> None: ...
-    def get_all_records(self) -> List[Dict[str, Any]]: ...
+    def store_vector(self, text_id: str, vector: list[float], metadata: dict[str, Any] | None = None) -> None: ...
+    def get_all_records(self) -> list[dict[str, Any]]: ...
     def clear(self) -> None: ...
 
     def close(self) -> None: ...
@@ -30,22 +30,22 @@ class EmbeddingEngine:
     """Generate TF-IDF-like vectors using only the Python standard library."""
 
     def __init__(self) -> None:
-        self.vocabulary: Dict[str, int] = {}
-        self.idf: Dict[str, float] = {}
-        self.documents: List[str] = []
+        self.vocabulary: dict[str, int] = {}
+        self.idf: dict[str, float] = {}
+        self.documents: list[str] = []
 
-    def tokenize(self, text: str) -> List[str]:
+    def tokenize(self, text: str) -> list[str]:
         text_clean = re.sub(r"[^\w\s]", "", text.lower())
         return [word for word in text_clean.split() if word]
 
-    def fit(self, texts: List[str]) -> None:
+    def fit(self, texts: list[str]) -> None:
         self.documents = list(texts)
         self.vocabulary.clear()
         self.idf.clear()
         if not texts:
             return
 
-        occurrences: Dict[str, int] = {}
+        occurrences: dict[str, int] = {}
         for doc in texts:
             for token in set(self.tokenize(doc)):
                 if token not in self.vocabulary:
@@ -56,7 +56,7 @@ class EmbeddingEngine:
         for term, frequency in occurrences.items():
             self.idf[term] = math.log((1 + count) / (1 + frequency)) + 1
 
-    def get_embedding(self, text: str) -> List[float]:
+    def get_embedding(self, text: str) -> list[float]:
         vector = [0.0] * max(len(self.vocabulary), 1)
         if not self.vocabulary:
             return vector
@@ -64,7 +64,7 @@ class EmbeddingEngine:
         if not tokens:
             return vector
 
-        tf: Dict[str, int] = {}
+        tf: dict[str, int] = {}
         for token in tokens:
             if token in self.vocabulary:
                 tf[token] = tf.get(token, 0) + 1
@@ -79,13 +79,13 @@ class VectorStore:
     """In-memory vector store retained as the lightweight library backend."""
 
     def __init__(self) -> None:
-        self.records: List[Dict[str, Any]] = []
+        self.records: list[dict[str, Any]] = []
 
-    def store_vector(self, text_id: str, vector: List[float], metadata: Optional[Dict[str, Any]] = None) -> None:
+    def store_vector(self, text_id: str, vector: list[float], metadata: dict[str, Any] | None = None) -> None:
         self.records = [record for record in self.records if record["id"] != text_id]
         self.records.append({"id": text_id, "vector": vector, "metadata": metadata or {}})
 
-    def get_all_records(self) -> List[Dict[str, Any]]:
+    def get_all_records(self) -> list[dict[str, Any]]:
         return self.records
 
     def clear(self) -> None:
@@ -94,7 +94,7 @@ class VectorStore:
 
 class SemanticSearch:
     @staticmethod
-    def cosine_similarity(v1: List[float], v2: List[float]) -> float:
+    def cosine_similarity(v1: list[float], v2: list[float]) -> float:
         if len(v1) != len(v2) or not v1:
             return 0.0
         dot = sum(a * b for a, b in zip(v1, v2))
@@ -104,7 +104,7 @@ class SemanticSearch:
             return 0.0
         return dot / (norm_a * norm_b)
 
-    def search(self, query_vector: List[float], records: List[Dict[str, Any]], limit: int = 5, threshold: float = 0.0) -> List[Dict[str, Any]]:
+    def search(self, query_vector: list[float], records: list[dict[str, Any]], limit: int = 5, threshold: float = 0.0) -> list[dict[str, Any]]:
         scored = []
         for record in records:
             score = self.cosine_similarity(query_vector, record["vector"])
@@ -117,7 +117,7 @@ class SemanticSearch:
 class Retriever:
     """Persistent semantic retriever with a pluggable vector store."""
 
-    def __init__(self, store: Optional[VectorStoreProtocol] = None, path: Optional[str] = None) -> None:
+    def __init__(self, store: VectorStoreProtocol | None = None, path: str | None = None) -> None:
         self.embedding_engine = EmbeddingEngine()
         if store is not None:
             self.vector_store = store
@@ -135,13 +135,13 @@ class Retriever:
             record["vector"] = self.embedding_engine.get_embedding(record["metadata"].get("text", ""))
             self.vector_store.store_vector(record["id"], record["vector"], record["metadata"])
 
-    def add_document(self, doc_id: str, text: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    def add_document(self, doc_id: str, text: str, metadata: dict[str, Any] | None = None) -> None:
         meta = dict(metadata or {})
         meta["text"] = text
         self.vector_store.store_vector(doc_id, [], meta)
         self._rebuild_embeddings()
 
-    def retrieve(self, query: str, limit: int = 5, threshold: float = 0.0) -> List[Dict[str, Any]]:
+    def retrieve(self, query: str, limit: int = 5, threshold: float = 0.0) -> list[dict[str, Any]]:
         records = self.vector_store.get_all_records()
         if not records or limit <= 0:
             return []

--- a/knowledge_platform/triple_store.py
+++ b/knowledge_platform/triple_store.py
@@ -1,9 +1,9 @@
 """
 Triple Store for YasinAI Knowledge Graph.
 """
+from __future__ import annotations
 
 import logging
-from typing import List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ class TripleStore:
 
     def __init__(self) -> None:
         # Triples are stored as tuples of strings (subject_name, predicate_name, object_name)
-        self._triples: List[Tuple[str, str, str]] = []
+        self._triples: list[tuple[str, str, str]] = []
 
     def add_triple(self, subject: str, predicate: str, obj: str) -> None:
         """Add a triple to the store if it does not already exist."""
@@ -37,11 +37,11 @@ class TripleStore:
         logger.warning(f"Attempted to remove non-existent triple: {triple}")
         return False
 
-    def query_triples(self, subject: Optional[str] = None, predicate: Optional[str] = None, obj: Optional[str] = None) -> List[Tuple[str, str, str]]:
+    def query_triples(self, subject: str | None = None, predicate: str | None = None, obj: str | None = None) -> list[tuple[str, str, str]]:
         """
         Query the triple store using wildcards. None acts as a wildcard.
         """
-        results: List[Tuple[str, str, str]] = []
+        results: list[tuple[str, str, str]] = []
         for s, p, o in self._triples:
             if subject is not None and s != subject:
                 continue
@@ -52,7 +52,7 @@ class TripleStore:
             results.append((s, p, o))
         return results
 
-    def list_all(self) -> List[Tuple[str, str, str]]:
+    def list_all(self) -> list[tuple[str, str, str]]:
         """List all stored triples."""
         return list(self._triples)
 

--- a/knowledge_platform/vector_store.py
+++ b/knowledge_platform/vector_store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 class SQLiteVectorStore:
@@ -32,11 +32,11 @@ class SQLiteVectorStore:
         self._connection.commit()
 
     @property
-    def records(self) -> List[Dict[str, Any]]:
+    def records(self) -> list[dict[str, Any]]:
         """Compatibility view matching the in-memory VectorStore API."""
         return self.get_all_records()
 
-    def store_vector(self, text_id: str, vector: List[float], metadata: Optional[Dict[str, Any]] = None) -> None:
+    def store_vector(self, text_id: str, vector: list[float], metadata: dict[str, Any] | None = None) -> None:
         self._connection.execute(
             """INSERT INTO vectors(id, vector, metadata) VALUES (?, ?, ?)
                ON CONFLICT(id) DO UPDATE SET
@@ -50,7 +50,7 @@ class SQLiteVectorStore:
         )
         self._connection.commit()
 
-    def get_all_records(self) -> List[Dict[str, Any]]:
+    def get_all_records(self) -> list[dict[str, Any]]:
         rows = self._connection.execute(
             "SELECT id, vector, metadata FROM vectors ORDER BY id"
         ).fetchall()

--- a/observability/metrics.py
+++ b/observability/metrics.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from functools import wraps
 from threading import Lock
 from time import monotonic
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 
 
 @dataclass
@@ -47,8 +47,8 @@ class MetricsRegistry:
     """Thread-safe in-process registry suitable for service adapters."""
 
     def __init__(self) -> None:
-        self._counters: Dict[str, Counter] = {}
-        self._timers: Dict[str, Timer] = {}
+        self._counters: dict[str, Counter] = {}
+        self._timers: dict[str, Timer] = {}
         self._lock = Lock()
 
     def counter(self, name: str) -> Counter:

--- a/security_platform/auth.py
+++ b/security_platform/auth.py
@@ -2,13 +2,13 @@
 Authentication Module for YasinAI Security Platform.
 Manages user credentials, hashing, tokens, and active sessions.
 """
+from __future__ import annotations
 
 import hashlib
 import hmac
 import logging
 import secrets
 import time
-from typing import Dict, Optional
 
 from security_platform.identity import IdentityManager
 
@@ -38,9 +38,9 @@ class AuthManager:
 
     def __init__(self, identity_manager: IdentityManager) -> None:
         self.identity_manager: IdentityManager = identity_manager
-        self._user_secrets: Dict[str, bytes] = {}      # username -> salt
-        self._password_hashes: Dict[str, bytes] = {}   # username -> PBKDF2 hash
-        self._sessions: Dict[str, Session] = {}        # token -> Session
+        self._user_secrets: dict[str, bytes] = {}      # username -> salt
+        self._password_hashes: dict[str, bytes] = {}   # username -> PBKDF2 hash
+        self._sessions: dict[str, Session] = {}        # token -> Session
 
     def register_credentials(self, username: str, password: str) -> None:
         """
@@ -59,7 +59,7 @@ class AuthManager:
         self._password_hashes[username] = pwd_hash
         logger.info(f"Successfully registered secure credentials for user '{username}'.")
 
-    def login(self, username: str, password: str, session_duration: int = 3600) -> Optional[str]:
+    def login(self, username: str, password: str, session_duration: int = 3600) -> str | None:
         """
         Authenticate user and return a secure session token if successful.
         """
@@ -131,7 +131,7 @@ class AuthManager:
         logger.debug(f"Token validation: Token is valid for user '{session.username}'.")
         return True
 
-    def get_session(self, token: str) -> Optional[Session]:
+    def get_session(self, token: str) -> Session | None:
         """
         Retrieve session if valid.
         """

--- a/security_platform/authorization.py
+++ b/security_platform/authorization.py
@@ -2,9 +2,9 @@
 Authorization Module for YasinAI Security Platform.
 Manages permissions, policies, access rules, and role-based access control (RBAC).
 """
+from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional, Set
 
 from security_platform.identity import IdentityManager
 
@@ -29,12 +29,12 @@ class Policy:
     Defines which roles are granted a set of permissions.
     """
 
-    def __init__(self, name: str, allowed_roles: List[str], permissions: List[str]) -> None:
+    def __init__(self, name: str, allowed_roles: list[str], permissions: list[str]) -> None:
         self.name: str = name
-        self.allowed_roles: Set[str] = set(allowed_roles)
-        self.permissions: Set[str] = set(permissions)
+        self.allowed_roles: set[str] = set(allowed_roles)
+        self.permissions: set[str] = set(permissions)
 
-    def permits(self, roles: Set[str], permission: str) -> bool:
+    def permits(self, roles: set[str], permission: str) -> bool:
         """Check if policy permits any of the given roles to access a permission."""
         if permission not in self.permissions:
             return False
@@ -52,8 +52,8 @@ class PolicyEngine:
 
     def __init__(self, identity_manager: IdentityManager) -> None:
         self.identity_manager: IdentityManager = identity_manager
-        self._permissions: Dict[str, Permission] = {}
-        self._policies: Dict[str, Policy] = {}
+        self._permissions: dict[str, Permission] = {}
+        self._policies: dict[str, Policy] = {}
 
     def create_permission(self, name: str, description: str = "") -> Permission:
         """Create and register a system permission."""
@@ -65,11 +65,11 @@ class PolicyEngine:
         logger.info(f"Successfully registered system permission: '{name}'")
         return permission
 
-    def get_permission(self, name: str) -> Optional[Permission]:
+    def get_permission(self, name: str) -> Permission | None:
         """Look up a registered permission."""
         return self._permissions.get(name)
 
-    def create_policy(self, name: str, allowed_roles: List[str], permissions: List[str]) -> Policy:
+    def create_policy(self, name: str, allowed_roles: list[str], permissions: list[str]) -> Policy:
         """Create and register an authorization policy."""
         if name in self._policies:
             logger.error(f"Cannot create policy: '{name}' already exists.")
@@ -90,7 +90,7 @@ class PolicyEngine:
         logger.info(f"Successfully registered authorization policy: '{name}'")
         return policy
 
-    def get_policy(self, name: str) -> Optional[Policy]:
+    def get_policy(self, name: str) -> Policy | None:
         """Look up a registered policy."""
         return self._policies.get(name)
 

--- a/security_platform/encryption.py
+++ b/security_platform/encryption.py
@@ -2,13 +2,13 @@
 Encryption and Key Management Module for YasinAI Security Platform.
 Provides secure SHA-256 hashing, AEAD encryption/decryption, and secret storage.
 """
+from __future__ import annotations
 
 import base64
 import hashlib
 import logging
 import os
 import secrets
-from typing import Dict, List, Optional
 
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -96,7 +96,7 @@ class SecretStore:
 
     def __init__(self, encryption_engine: EncryptionEngine) -> None:
         self.engine: EncryptionEngine = encryption_engine
-        self._secrets: Dict[str, str] = {}
+        self._secrets: dict[str, str] = {}
 
     def set_secret(self, name: str, secret_value: str, master_key: str) -> None:
         """Encrypt and store a secret after validating the environment master key."""
@@ -109,7 +109,7 @@ class SecretStore:
             )
         self._secrets[name] = self.engine.encrypt(secret_value, master_key)
 
-    def get_secret(self, name: str, master_key: str) -> Optional[str]:
+    def get_secret(self, name: str, master_key: str) -> str | None:
         """Decrypt and retrieve a stored secret."""
         expected_key = os.environ.get("YASINAI_MASTER_KEY")
         if not expected_key or master_key != expected_key:
@@ -134,6 +134,6 @@ class SecretStore:
             return True
         return False
 
-    def list_secrets(self) -> List[str]:
+    def list_secrets(self) -> list[str]:
         """List secret names without exposing secret values."""
         return list(self._secrets.keys())

--- a/security_platform/identity.py
+++ b/security_platform/identity.py
@@ -2,9 +2,9 @@
 Identity Module for YasinAI Security Platform.
 Manages Users, Roles, and user-role associations.
 """
+from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +27,9 @@ class User:
     Represents a User Identity within the YasinAI ecosystem.
     """
 
-    def __init__(self, username: str, roles: Optional[List[str]] = None, active: bool = True) -> None:
+    def __init__(self, username: str, roles: list[str] | None = None, active: bool = True) -> None:
         self.username: str = username
-        self.roles: Set[str] = set(roles) if roles else set()
+        self.roles: set[str] = set(roles) if roles else set()
         self.active: bool = active
 
     def add_role(self, role_name: str) -> None:
@@ -60,8 +60,8 @@ class IdentityManager:
     """
 
     def __init__(self) -> None:
-        self._users: Dict[str, User] = {}
-        self._roles: Dict[str, Role] = {}
+        self._users: dict[str, User] = {}
+        self._roles: dict[str, Role] = {}
 
     def create_role(self, name: str, description: str = "") -> Role:
         """Create and register a security role."""
@@ -73,7 +73,7 @@ class IdentityManager:
         logger.info(f"Successfully created role: '{name}'")
         return role
 
-    def get_role(self, name: str) -> Optional[Role]:
+    def get_role(self, name: str) -> Role | None:
         """Look up a registered role."""
         return self._roles.get(name)
 
@@ -89,7 +89,7 @@ class IdentityManager:
         logger.warning(f"Attempted to delete non-existent role: '{name}'")
         return False
 
-    def create_user(self, username: str, roles: Optional[List[str]] = None, active: bool = True) -> User:
+    def create_user(self, username: str, roles: list[str] | None = None, active: bool = True) -> User:
         """Create and register a user identity."""
         if username in self._users:
             logger.error(f"Cannot create user: '{username}' already exists.")
@@ -107,7 +107,7 @@ class IdentityManager:
         logger.info(f"Successfully created user identity: '{username}'")
         return user
 
-    def get_user(self, username: str) -> Optional[User]:
+    def get_user(self, username: str) -> User | None:
         """Look up a user identity."""
         return self._users.get(username)
 
@@ -142,10 +142,10 @@ class IdentityManager:
         logger.warning(f"Failed to revoke role '{role_name}' from user '{username}' (user not found).")
         return False
 
-    def list_users(self) -> List[User]:
+    def list_users(self) -> list[User]:
         """List all registered users."""
         return list(self._users.values())
 
-    def list_roles(self) -> List[Role]:
+    def list_roles(self) -> list[Role]:
         """List all registered roles."""
         return list(self._roles.values())

--- a/security_platform/monitoring.py
+++ b/security_platform/monitoring.py
@@ -2,10 +2,11 @@
 Monitoring and Audit Logging Module for YasinAI Security Platform.
 Records security events and contains rule-based heuristics for threat detection.
 """
+from __future__ import annotations
 
 import logging
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ class SecurityEvent:
         self.details: str = details
         self.severity: str = severity  # "low", "medium", "high", "critical"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert security event to dictionary format."""
         return {
             "timestamp": self.timestamp,
@@ -44,7 +45,7 @@ class AuditLogger:
     """
 
     def __init__(self) -> None:
-        self._events: List[SecurityEvent] = []
+        self._events: list[SecurityEvent] = []
 
     def log_event(self, event_type: str, username: str, status: str, details: str, severity: str = "low") -> SecurityEvent:
         """
@@ -55,13 +56,13 @@ class AuditLogger:
         logger.info(f"AuditLog Event registered: {event}")
         return event
 
-    def get_logs(self, event_type: Optional[str] = None, username: Optional[str] = None, min_severity: Optional[str] = None) -> List[SecurityEvent]:
+    def get_logs(self, event_type: str | None = None, username: str | None = None, min_severity: str | None = None) -> list[SecurityEvent]:
         """
         Filter and return matching logs.
         """
         logger.debug(f"Retrieving audit logs with filters: event_type={event_type}, username={username}, min_severity={min_severity}")
-        severity_ranks: Dict[str, int] = {"low": 1, "medium": 2, "high": 3, "critical": 4}
-        filtered: List[SecurityEvent] = self._events
+        severity_ranks: dict[str, int] = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+        filtered: list[SecurityEvent] = self._events
 
         if event_type:
             filtered = [e for e in filtered if e.event_type == event_type]
@@ -87,7 +88,7 @@ class ThreatDetector:
     def __init__(self, audit_logger: AuditLogger) -> None:
         self.audit_logger: AuditLogger = audit_logger
 
-    def detect_threats(self) -> List[Dict[str, Any]]:
+    def detect_threats(self) -> list[dict[str, Any]]:
         """
         Scan logs to identify known patterns of malicious behavior.
         Currently supports:
@@ -96,13 +97,13 @@ class ThreatDetector:
           - Deactivated User Access Attempt: 1+ attempt of access by an inactive/deleted user profile.
         """
         logger.debug("Running threat detection scan on audit logs...")
-        threats: List[Dict[str, Any]] = []
+        threats: list[dict[str, Any]] = []
         logs = self.audit_logger.get_logs()
 
         # Group login failure counts by user
-        login_failures: Dict[str, int] = {}
+        login_failures: dict[str, int] = {}
         # Group access denied counts by user
-        access_denied_counts: Dict[str, int] = {}
+        access_denied_counts: dict[str, int] = {}
 
         for log in logs:
             user = log.username

--- a/security_platform/scanner.py
+++ b/security_platform/scanner.py
@@ -11,7 +11,7 @@ import re
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import ClassVar
 
 
 @dataclass
@@ -21,7 +21,7 @@ class SecurityFinding:
     passed: bool
     severity: str
     details: str
-    path: Optional[str] = None
+    path: str | None = None
 
 
 class SecurityScanner:
@@ -33,11 +33,11 @@ class SecurityScanner:
         ("aws_access_key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
         ("generic_secret", re.compile(r"(?i)\b(?:api[_-]?key|secret|token|password|passwd)\b\s*[:=]\s*[\"'][^\"']{12,}[\"']")),
     )
-    SKIP_DIRS = {".git", ".venv", "venv", "__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "dist", "build"}
-    TEXT_SUFFIXES = {".py", ".toml", ".yml", ".yaml", ".json", ".ini", ".cfg", ".conf", ".txt", ".md", ".sh", ".env"}
-    SECRET_FILENAMES = {".env", ".env.local", ".env.production", "credentials", "credentials.json"}
+    SKIP_DIRS: ClassVar[set[str]] = {".git", ".venv", "venv", "__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "dist", "build"}
+    TEXT_SUFFIXES: ClassVar[set[str]] = {".py", ".toml", ".yml", ".yaml", ".json", ".ini", ".cfg", ".conf", ".txt", ".md", ".sh", ".env"}
+    SECRET_FILENAMES: ClassVar[set[str]] = {".env", ".env.local", ".env.production", "credentials", "credentials.json"}
 
-    def __init__(self, root: Optional[Path] = None) -> None:
+    def __init__(self, root: Path | None = None) -> None:
         self.root = Path(root or Path.cwd()).resolve()
 
     def _iter_files(self) -> Iterable[Path]:
@@ -50,8 +50,8 @@ class SecurityScanner:
             if path.suffix.lower() in self.TEXT_SUFFIXES or path.name in self.SECRET_FILENAMES:
                 yield path
 
-    def check_secrets(self) -> List[SecurityFinding]:
-        findings: List[SecurityFinding] = []
+    def check_secrets(self) -> list[SecurityFinding]:
+        findings: list[SecurityFinding] = []
         for path in self._iter_files():
             try:
                 text = path.read_text(encoding="utf-8", errors="ignore")
@@ -76,8 +76,8 @@ class SecurityScanner:
             return SecurityFinding("SEC_POLICY_001", "Secret ignore policy", False, "high", f"Missing ignore patterns: {', '.join(missing)}")
         return SecurityFinding("SEC_POLICY_001", "Secret ignore policy", True, "high", "Repository ignores common secret-bearing files.")
 
-    def check_file_permissions(self) -> List[SecurityFinding]:
-        findings: List[SecurityFinding] = []
+    def check_file_permissions(self) -> list[SecurityFinding]:
+        findings: list[SecurityFinding] = []
         for path in self._iter_files():
             try:
                 mode = path.stat().st_mode
@@ -97,7 +97,7 @@ class SecurityScanner:
             if AESGCM is None or not hasattr(EncryptionEngine, "encrypt"):
                 raise RuntimeError("required AEAD implementation is unavailable")
             return SecurityFinding("SEC_CRYPTO_001", "Authenticated encryption", True, "critical", "AES-GCM dependency and encryption engine are available.")
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 — crypto probe must not crash the security scan
             return SecurityFinding("SEC_CRYPTO_001", "Authenticated encryption", False, "critical", f"Encryption security check failed: {exc}")
 
     def check_policy_files(self) -> SecurityFinding:
@@ -107,8 +107,8 @@ class SecurityScanner:
             return SecurityFinding("SEC_POLICY_002", "Security policy documentation", False, "medium", f"Missing policy files: {', '.join(missing)}")
         return SecurityFinding("SEC_POLICY_002", "Security policy documentation", True, "medium", "Security truth and engineering policy documents are present.")
 
-    def scan(self) -> Dict[str, object]:
-        findings: List[SecurityFinding] = []
+    def scan(self) -> dict[str, object]:
+        findings: list[SecurityFinding] = []
         findings.extend(self.check_secrets())
         findings.append(self.check_secret_policy())
         findings.extend(self.check_file_permissions())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -441,12 +441,12 @@ def test_additional_cli_coverage(capsys):
     import subprocess
     env = os.environ.copy()
     env["PYTHONPATH"] = "."
-    res = subprocess.run([sys.executable, "yasinai/cli/main.py", "--help"], capture_output=True, text=True, env=env)
+    res = subprocess.run([sys.executable, "yasinai/cli/main.py", "--help"], capture_output=True, text=True, env=env, check=False)
     assert res.returncode == 0
     assert "YasinAI Command Line management interface" in res.stdout
 
     # Run module main
-    res_mod = subprocess.run([sys.executable, "-m", "yasinai.cli", "--help"], capture_output=True, text=True, env=env)
+    res_mod = subprocess.run([sys.executable, "-m", "yasinai.cli", "--help"], capture_output=True, text=True, env=env, check=False)
     assert res_mod.returncode == 0
 
     # 9. Call main(None) to execute line 302 in current process

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -58,10 +58,12 @@ def test_docker_manager_compose_checks():
         assert manager.check_docker_compose_available() is True
 
     # Test "docker compose" subcommand check
-    with patch("shutil.which", side_effect=lambda name: "/usr/bin/docker" if name == "docker" else None):
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
-            assert manager.check_docker_compose_available() is True
+    with (
+        patch("shutil.which", side_effect=lambda name: "/usr/bin/docker" if name == "docker" else None),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        assert manager.check_docker_compose_available() is True
 
 
 def test_docker_manager_generation(tmp_path):
@@ -168,9 +170,11 @@ def test_package_builder_build(tmp_path):
 def test_additional_deployment_coverage(tmp_path):
     # 1. DockerManager compose check subprocess exceptions (lines 47-51)
     manager = DockerManager()
-    with patch("shutil.which", side_effect=lambda name: "/usr/bin/docker" if name == "docker" else None):
-        with patch("subprocess.run", side_effect=Exception("Subprocess failed")):
-            assert manager.check_docker_compose_available() is False
+    with (
+        patch("shutil.which", side_effect=lambda name: "/usr/bin/docker" if name == "docker" else None),
+        patch("subprocess.run", side_effect=Exception("Subprocess failed")),
+    ):
+        assert manager.check_docker_compose_available() is False
 
     # DockerManager when check_docker_available is False (lines 50-51)
     with patch.object(DockerManager, "check_docker_available", return_value=False):

--- a/tests/test_knowledge_platform.py
+++ b/tests/test_knowledge_platform.py
@@ -28,15 +28,15 @@ from knowledge_platform.triple_store import TripleStore
 def test_short_term_memory_lifecycle():
     stm = ShortTermMemory(capacity=3)
 
-    e1 = stm.store("first msg", {"user": "alice"})
-    e2 = stm.store("second msg", {"user": "bob"})
-    e3 = stm.store("third msg")
+    _e1 = stm.store("first msg", {"user": "alice"})
+    _e2 = stm.store("second msg", {"user": "bob"})
+    _e3 = stm.store("third msg")
 
     assert len(stm.memory) == 3
     assert stm.memory[0]["content"] == "first msg"
 
     # Check eviction (FIFO)
-    e4 = stm.store("fourth msg")
+    _e4 = stm.store("fourth msg")
     assert len(stm.memory) == 3
     assert "first msg" not in [m["content"] for m in stm.memory]
     assert stm.memory[0]["content"] == "second msg"

--- a/tests/test_knowledge_service.py
+++ b/tests/test_knowledge_service.py
@@ -267,8 +267,11 @@ def test_unsupported_memory_operation(svc):
         key = None
         content = None
         limit = None
-        metadata = {}
+        metadata: dict = None  # type: ignore[assignment]
         context = None
+
+        def __init__(self):
+            self.metadata = {}
 
     resp = svc.memory(FakeReq())  # type: ignore[arg-type]
     assert resp.success is False

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2,6 +2,8 @@
 Tests for Yasin-AI Provider Abstraction Layer
 Phase 2.6
 """
+from __future__ import annotations
+
 import pytest
 
 from yasinai.providers.base import (
@@ -22,7 +24,7 @@ from yasinai.providers.router import ProviderRouter, ProviderUnavailableError
 class StubGenerationProvider(ProviderBase):
     """Minimal stub that supports GENERATION and is always available."""
 
-    def __init__(self, name: str = "stub-gen", models: list = None, available: bool = True):
+    def __init__(self, name: str = "stub-gen", models: list | None = None, available: bool = True):
         self._name = name
         self._models = models or ["stub-model-v1"]
         self._available = available

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -105,16 +105,20 @@ def test_bootstrap_rejects_non_callable_registration_hook():
     bootstrap = Bootstrap(runtime)
     mock_module = MagicMock()
     mock_module.register_module = "invalid"
-    with patch("importlib.import_module", return_value=mock_module):
-        with pytest.raises(ImportError, match="register_module is not callable"):
+    with (
+        patch("importlib.import_module", return_value=mock_module),
+        pytest.raises(ImportError, match="register_module is not callable"),
+    ):
             bootstrap.discover_and_load(["mock_mod"])
 
 
 def test_bootstrap_load_failure():
     runtime = MagicMock()
     bootstrap = Bootstrap(runtime)
-    with patch("importlib.import_module", side_effect=ImportError("Module not found")):
-        with pytest.raises(ImportError, match="invalid_mod"):
+    with (
+        patch("importlib.import_module", side_effect=ImportError("Module not found")),
+        pytest.raises(ImportError, match="invalid_mod"),
+    ):
             bootstrap.discover_and_load(["invalid_mod"])
 
 
@@ -165,9 +169,11 @@ def test_runtime_orchestrated_start_is_idempotent():
 
 def test_runtime_start_failure_cleans_up():
     runtime = Runtime(config_defaults={"modules": ["invalid_mod"]})
-    with patch("importlib.import_module", side_effect=ImportError("Module not found")):
-        with pytest.raises(RuntimeError, match="Runtime startup failed"):
-            runtime.start()
+    with (
+        patch("importlib.import_module", side_effect=ImportError("Module not found")),
+        pytest.raises(RuntimeError, match="Runtime startup failed"),
+    ):
+        runtime.start()
     assert runtime.state == Runtime.FAILED
     assert runtime.system_info.status == "failed"
     assert runtime.services.list_services() == {}

--- a/tests/test_security_platform.py
+++ b/tests/test_security_platform.py
@@ -127,8 +127,8 @@ def test_policy_engine_authorization():
     policy_engine = PolicyEngine(id_mgr)
 
     # Create permissions
-    read_perm = policy_engine.create_permission("data:read", "Read access to database")
-    write_perm = policy_engine.create_permission("data:write", "Write access to database")
+    _read_perm = policy_engine.create_permission("data:read", "Read access to database")
+    _write_perm = policy_engine.create_permission("data:write", "Write access to database")
 
     # Create policy
     policy_engine.create_policy("AdminAccess", ["admin"], ["data:read", "data:write"])
@@ -163,7 +163,7 @@ def test_encryption_engine():
 
     # Different key should fail decryption
     another_key = engine.generate_key()
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         engine.decrypt(ciphertext, another_key)
 
 

--- a/yasinai/cli/main.py
+++ b/yasinai/cli/main.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import argparse
 import json
 import logging
 import sys
-from typing import List, Optional
 
 from yasinai.core.runtime import Runtime
 
@@ -38,7 +39,7 @@ def handle_status(args: argparse.Namespace) -> int:
         logger.info("Successfully displayed status.")
         return 0
     except Exception as e:
-        logger.error(f"Error checking status: {e}", exc_info=True)
+        logger.exception("Error checking status")
         print(f"Error checking status: {e}", file=sys.stderr)
         return 1
 
@@ -88,7 +89,7 @@ def handle_agent_create(args: argparse.Namespace) -> int:
         logger.info(f"Successfully created agent: {agent.name}")
         return 0
     except Exception as e:
-        logger.error(f"Error creating agent: {e}", exc_info=True)
+        logger.exception("Error creating agent")
         print(f"Error creating agent: {e}", file=sys.stderr)
         return 1
 
@@ -138,7 +139,7 @@ def handle_memory_search(args: argparse.Namespace) -> int:
         logger.info("Successfully searched memory.")
         return 0
     except Exception as e:
-        logger.error(f"Error searching memory: {e}", exc_info=True)
+        logger.exception("Error searching memory")
         print(f"Error searching memory: {e}", file=sys.stderr)
         return 1
 
@@ -185,7 +186,7 @@ def handle_security_check(args: argparse.Namespace) -> int:
         logger.info("Successfully executed security check.")
         return 0
     except Exception as e:
-        logger.error(f"Error checking security: {e}", exc_info=True)
+        logger.exception("Error checking security")
         print(f"Error checking security: {e}", file=sys.stderr)
         return 1
 
@@ -221,7 +222,7 @@ def handle_package_build(args: argparse.Namespace) -> int:
         logger.info(f"Successfully built package v{version}")
         return 0
     except Exception as e:
-        logger.error(f"Error building package: {e}", exc_info=True)
+        logger.exception("Error building package")
         print(f"Error building package: {e}", file=sys.stderr)
         return 1
 
@@ -242,7 +243,7 @@ def handle_serve(args: argparse.Namespace) -> int:
 
     # Validate interval
     if interval <= 0:
-        logger.error("Interval must be a positive integer.")
+        logger.exception("Interval must be a positive integer.")
         print("Error: Interval must be a positive integer.", file=sys.stderr)
         return 1
 
@@ -304,7 +305,7 @@ def handle_serve(args: argparse.Namespace) -> int:
                 slept += 1
 
     except Exception as e:
-        logger.error(f"Error in serve loop: {e}", exc_info=True)
+        logger.exception("Error in serve loop")
         print(f"Error in serve loop: {e}", file=sys.stderr)
         return 1
     finally:
@@ -393,7 +394,7 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Optional[List[str]] = None) -> None:
+def main(argv: list[str] | None = None) -> None:
     """
     Main CLI entrypoint. Parses command line arguments and executes requested subcommands.
     """
@@ -408,20 +409,19 @@ def main(argv: Optional[List[str]] = None) -> None:
         sys.exit(0)
 
     # For commands with nested subcommands, ensure subcommand is provided
-    if args.command in ("agent", "memory", "security", "package"):
-        if not getattr(args, "subcommand", None):
-            # Print subcommand help
-            sub_parsers_actions = [
-                action for action in parser._subparsers._actions
-                if isinstance(action, argparse._SubParsersAction)
-            ]
-            for action in sub_parsers_actions:
-                subcommand_parser = action.choices.get(args.command)
-                if subcommand_parser:
-                    subcommand_parser.print_help()
-                    sys.exit(0)
-            parser.print_help()
-            sys.exit(0)
+    if args.command in ("agent", "memory", "security", "package") and not getattr(args, "subcommand", None):
+        # Print subcommand help
+        sub_parsers_actions = [
+            action for action in parser._subparsers._actions
+            if isinstance(action, argparse._SubParsersAction)
+        ]
+        for action in sub_parsers_actions:
+            subcommand_parser = action.choices.get(args.command)
+            if subcommand_parser:
+                subcommand_parser.print_help()
+                sys.exit(0)
+        parser.print_help()
+        sys.exit(0)
 
     if hasattr(args, "func"):
         # Propagate the top-level --json option to nested args if not present

--- a/yasinai/cli/security_entrypoint.py
+++ b/yasinai/cli/security_entrypoint.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import importlib
 import json
 import sys
-from typing import List, Optional
 
 
-def security_check(argv: List[str]) -> int:
+def security_check(argv: list[str]) -> int:
     from security_platform.scanner import SecurityScanner
 
     json_output = "--json" in argv
@@ -30,7 +29,7 @@ def security_check(argv: List[str]) -> int:
     return 0 if report["failed_items"] == 0 else 1
 
 
-def main(argv: Optional[List[str]] = None) -> None:
+def main(argv: list[str] | None = None) -> None:
     args = list(sys.argv[1:] if argv is None else argv)
     if len(args) >= 2 and args[0] == "security" and args[1] == "check":
         raise SystemExit(security_check(args[2:]))

--- a/yasinai/contracts/__init__.py
+++ b/yasinai/contracts/__init__.py
@@ -49,31 +49,31 @@ from yasinai.contracts.rag import (
 __all__ = [
     # base
     "CapabilityError",
+    "CapabilityMetadata",
     "CapabilityUnavailableError",
     "ContractViolationError",
-    "ObservabilityContext",
-    "CapabilityMetadata",
-    # memory
-    "MemoryRequest",
-    "MemoryResponse",
-    "MemoryEntry",
-    "MemoryType",
-    # knowledge
-    "KnowledgeQuery",
-    "KnowledgeResult",
-    "KnowledgeEntry",
-    "KnowledgeQueryType",
     # embedding
     "EmbeddingRequest",
     "EmbeddingResponse",
     "EmbeddingVector",
+    # generation
+    "GenerationRequest",
+    "GenerationResult",
+    "KnowledgeEntry",
+    # knowledge
+    "KnowledgeQuery",
+    "KnowledgeQueryType",
+    "KnowledgeResult",
+    "MemoryEntry",
+    # memory
+    "MemoryRequest",
+    "MemoryResponse",
+    "MemoryType",
+    "ObservabilityContext",
     # plugin
     "PluginContract",
     "PluginInvokeRequest",
     "PluginInvokeResponse",
-    # generation
-    "GenerationRequest",
-    "GenerationResult",
     # rag
     "RagRequest",
     "RagResult",

--- a/yasinai/contracts/base.py
+++ b/yasinai/contracts/base.py
@@ -4,7 +4,7 @@ Base types shared across all Yasin-AI Capability Contracts v1.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any
 
 
 class CapabilityError(Exception):
@@ -14,7 +14,7 @@ class CapabilityError(Exception):
         super().__init__(message)
         self.code = code
 
-    def as_dict(self) -> Dict[str, str]:
+    def as_dict(self) -> dict[str, str]:
         return {"error": str(self), "code": self.code}
 
 
@@ -40,10 +40,10 @@ class ContractViolationError(CapabilityError):
 class ObservabilityContext:
     """Opaque tracing/logging context passed through capability calls."""
 
-    trace_id: Optional[str] = None
-    span_id: Optional[str] = None
-    caller: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    trace_id: str | None = None
+    span_id: str | None = None
+    caller: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -53,4 +53,4 @@ class CapabilityMetadata:
     capability: str
     contract_version: str = "v1"
     platform_version: str = "1.1.2"
-    provider: Optional[str] = None
+    provider: str | None = None

--- a/yasinai/contracts/embedding.py
+++ b/yasinai/contracts/embedding.py
@@ -9,7 +9,7 @@ without changing this contract.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from yasinai.contracts.base import (
     CapabilityMetadata,
@@ -30,10 +30,10 @@ class EmbeddingRequest:
         context:    Observability tracing context
     """
 
-    texts: List[str]
-    model: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
-    context: Optional[ObservabilityContext] = None
+    texts: list[str]
+    model: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    context: ObservabilityContext | None = None
 
     def __post_init__(self) -> None:
         if not self.texts:
@@ -51,9 +51,9 @@ class EmbeddingVector:
     """A single embedding result."""
 
     text: str
-    vector: List[float]
-    model: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    vector: list[float]
+    model: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -69,8 +69,8 @@ class EmbeddingResponse:
     """
 
     success: bool
-    vectors: List[EmbeddingVector] = field(default_factory=list)
-    error: Optional[str] = None
+    vectors: list[EmbeddingVector] = field(default_factory=list)
+    error: str | None = None
     meta: CapabilityMetadata = field(
         default_factory=lambda: CapabilityMetadata(capability="embedding")
     )

--- a/yasinai/contracts/generation.py
+++ b/yasinai/contracts/generation.py
@@ -8,7 +8,7 @@ Consumers must not import yasinai.providers directly.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from yasinai.contracts.base import (
     CapabilityMetadata,
@@ -35,14 +35,14 @@ class GenerationRequest:
     """
 
     prompt: str
-    model: Optional[str] = None
+    model: str | None = None
     max_tokens: int = 1024
     temperature: float = 0.7
-    system_prompt: Optional[str] = None
-    stop_sequences: List[str] = field(default_factory=list)
-    provider: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
-    context: Optional[ObservabilityContext] = None
+    system_prompt: str | None = None
+    stop_sequences: list[str] = field(default_factory=list)
+    provider: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    context: ObservabilityContext | None = None
 
     MAX_TOKENS_LIMIT = 32000
 
@@ -80,12 +80,12 @@ class GenerationResult:
 
     success: bool
     text: str = ""
-    model: Optional[str] = None
-    provider: Optional[str] = None
+    model: str | None = None
+    provider: str | None = None
     input_tokens: int = 0
     output_tokens: int = 0
-    finish_reason: Optional[str] = None
-    error: Optional[str] = None
+    finish_reason: str | None = None
+    error: str | None = None
     meta: CapabilityMetadata = field(
         default_factory=lambda: CapabilityMetadata(capability="generation")
     )

--- a/yasinai/contracts/knowledge.py
+++ b/yasinai/contracts/knowledge.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from yasinai.contracts.base import (
     CapabilityMetadata,
@@ -41,13 +41,13 @@ class KnowledgeQuery:
     """
 
     query_type: KnowledgeQueryType
-    text: Optional[str] = None
-    subject: Optional[str] = None
-    predicate: Optional[str] = None
-    relation: Optional[str] = None
+    text: str | None = None
+    subject: str | None = None
+    predicate: str | None = None
+    relation: str | None = None
     top_k: int = 5
-    metadata: Dict[str, Any] = field(default_factory=dict)
-    context: Optional[ObservabilityContext] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    context: ObservabilityContext | None = None
 
     TOP_K_LIMIT = 100
 
@@ -62,16 +62,14 @@ class KnowledgeQuery:
             raise ContractViolationError(
                 "KnowledgeQuery: SEMANTIC query requires 'text'"
             )
-        if self.query_type in {KnowledgeQueryType.GRAPH, KnowledgeQueryType.TRIPLE}:
-            if not self.subject:
-                raise ContractViolationError(
-                    f"KnowledgeQuery: {self.query_type} query requires 'subject'"
-                )
-        if self.query_type == KnowledgeQueryType.REASONING:
-            if not self.subject or not self.relation:
-                raise ContractViolationError(
-                    "KnowledgeQuery: REASONING query requires 'subject' and 'relation'"
-                )
+        if self.query_type in {KnowledgeQueryType.GRAPH, KnowledgeQueryType.TRIPLE} and not self.subject:
+            raise ContractViolationError(
+                f"KnowledgeQuery: {self.query_type} query requires 'subject'"
+            )
+        if self.query_type == KnowledgeQueryType.REASONING and (not self.subject or not self.relation):
+            raise ContractViolationError(
+                "KnowledgeQuery: REASONING query requires 'subject' and 'relation'"
+            )
 
 
 @dataclass(frozen=True)
@@ -80,8 +78,8 @@ class KnowledgeEntry:
 
     content: Any
     score: float = 1.0
-    source: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    source: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -97,8 +95,8 @@ class KnowledgeResult:
     """
 
     success: bool
-    entries: List[KnowledgeEntry] = field(default_factory=list)
-    error: Optional[str] = None
+    entries: list[KnowledgeEntry] = field(default_factory=list)
+    error: str | None = None
     meta: CapabilityMetadata = field(
         default_factory=lambda: CapabilityMetadata(capability="knowledge")
     )

--- a/yasinai/contracts/memory.py
+++ b/yasinai/contracts/memory.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from yasinai.contracts.base import (
     CapabilityMetadata,
@@ -39,11 +39,11 @@ class MemoryRequest:
 
     operation: str
     memory_type: MemoryType = MemoryType.SHORT_TERM
-    key: Optional[str] = None
-    content: Optional[Any] = None
-    limit: Optional[int] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
-    context: Optional[ObservabilityContext] = None
+    key: str | None = None
+    content: Any | None = None
+    limit: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    context: ObservabilityContext | None = None
 
     LIMIT_LIMIT = 1000
 
@@ -62,8 +62,11 @@ class MemoryRequest:
                 )
         if self.operation == "store" and self.content is None:
             raise ContractViolationError("MemoryRequest: 'store' operation requires 'content'")
-        if self.memory_type == MemoryType.LONG_TERM and self.operation in {"store", "retrieve", "delete"}:
-            if not self.key:
+        if (
+            self.memory_type == MemoryType.LONG_TERM
+            and self.operation in {"store", "retrieve", "delete"}
+            and not self.key
+        ):
                 raise ContractViolationError(
                     f"MemoryRequest: long-term '{self.operation}' requires 'key'"
                 )
@@ -75,8 +78,8 @@ class MemoryEntry:
 
     content: Any
     timestamp: float
-    key: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    key: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -94,10 +97,10 @@ class MemoryResponse:
     """
 
     success: bool
-    entries: List[MemoryEntry] = field(default_factory=list)
-    entry: Optional[MemoryEntry] = None
+    entries: list[MemoryEntry] = field(default_factory=list)
+    entry: MemoryEntry | None = None
     deleted: bool = False
-    error: Optional[str] = None
+    error: str | None = None
     meta: CapabilityMetadata = field(
         default_factory=lambda: CapabilityMetadata(capability="memory")
     )

--- a/yasinai/contracts/plugin.py
+++ b/yasinai/contracts/plugin.py
@@ -7,7 +7,7 @@ Backed by developer_platform.sdk — consumers must not import that directly.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from yasinai.contracts.base import (
     CapabilityMetadata,
@@ -23,7 +23,7 @@ class PluginContract:
     name: str
     version: str
     description: str
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -39,9 +39,9 @@ class PluginInvokeRequest:
     """
 
     name: str
-    args: List[Any] = field(default_factory=list)
-    kwargs: Dict[str, Any] = field(default_factory=dict)
-    context: Optional[ObservabilityContext] = None
+    args: list[Any] = field(default_factory=list)
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    context: ObservabilityContext | None = None
 
     def __post_init__(self) -> None:
         if not self.name or not self.name.strip():
@@ -64,7 +64,7 @@ class PluginInvokeResponse:
 
     success: bool
     result: Any = None
-    error: Optional[str] = None
+    error: str | None = None
     meta: CapabilityMetadata = field(
         default_factory=lambda: CapabilityMetadata(capability="plugin")
     )

--- a/yasinai/contracts/rag.py
+++ b/yasinai/contracts/rag.py
@@ -7,7 +7,7 @@ Orchestrated by yasinai.services.RagService.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from yasinai.contracts.base import (
     CapabilityMetadata,
@@ -40,13 +40,13 @@ class RagRequest:
     top_k: int = 5
     include_memory: bool = False
     memory_limit: int = 5
-    model: Optional[str] = None
-    provider: Optional[str] = None
+    model: str | None = None
+    provider: str | None = None
     max_tokens: int = 1024
     temperature: float = 0.7
-    system_prompt: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
-    context: Optional[ObservabilityContext] = None
+    system_prompt: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    context: ObservabilityContext | None = None
 
     TOP_K_LIMIT = 100
     MEMORY_LIMIT_LIMIT = 1000
@@ -92,12 +92,12 @@ class RagResult:
 
     success: bool
     answer: str = ""
-    sources: List[KnowledgeEntry] = field(default_factory=list)
-    model: Optional[str] = None
-    provider: Optional[str] = None
+    sources: list[KnowledgeEntry] = field(default_factory=list)
+    model: str | None = None
+    provider: str | None = None
     input_tokens: int = 0
     output_tokens: int = 0
-    error: Optional[str] = None
+    error: str | None = None
     meta: CapabilityMetadata = field(
         default_factory=lambda: CapabilityMetadata(capability="rag")
     )

--- a/yasinai/core/bootstrap.py
+++ b/yasinai/core/bootstrap.py
@@ -1,6 +1,6 @@
 import importlib
 import logging
-from typing import Any, List
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -10,16 +10,16 @@ class Bootstrap:
 
     def __init__(self, runtime: Any) -> None:
         self.runtime = runtime
-        self.loaded_modules: List[str] = []
+        self.loaded_modules: list[str] = []
 
-    def discover_and_load(self, module_names: List[str]) -> List[str]:
+    def discover_and_load(self, module_names: list[str]) -> list[str]:
         """Import modules and invoke their optional registration hook.
 
         Duplicate module names are ignored while preserving configuration order.
         If a module fails, the exception is wrapped with the module name and
         modules successfully loaded before the failure remain recorded.
         """
-        loaded: List[str] = []
+        loaded: list[str] = []
         seen = set(self.loaded_modules)
         for name in module_names:
             if name in seen:
@@ -38,7 +38,7 @@ class Bootstrap:
                 seen.add(name)
                 logger.info("Successfully bootstrapped module: '%s'", name)
             except Exception as exc:
-                logger.error("Failed to bootstrap module '%s'", name, exc_info=True)
+                logger.exception("Failed to bootstrap module '%s'", name)
                 raise ImportError(f"Failed to bootstrap and load module '{name}': {exc}") from exc
         return loaded
 

--- a/yasinai/core/config.py
+++ b/yasinai/core/config.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
-from typing import Any, Dict, Optional
+from typing import Any
 
 # Setup local module logger
 logger = logging.getLogger(__name__)
@@ -13,11 +15,11 @@ class Config:
     Supports default dictionary values, file-based loading (JSON), and environment variable overrides.
     """
 
-    def __init__(self, defaults: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, defaults: dict[str, Any] | None = None) -> None:
         """
         Initialize the Configuration with optional defaults.
         """
-        self._config: Dict[str, Any] = {
+        self._config: dict[str, Any] = {
             "app_name": "YasinAI",
             "version": "1.1.2",
             "environment": "production",
@@ -46,9 +48,9 @@ class Config:
                     logger.info(f"Successfully loaded configuration from {filepath}")
                     return True
                 else:
-                    logger.error(f"Configuration file {filepath} does not contain a valid JSON object.")
-        except Exception as e:
-            logger.error(f"Error loading configuration from file {filepath}: {e}", exc_info=True)
+                    logger.exception(f"Configuration file {filepath} does not contain a valid JSON object.")
+        except (OSError, json.JSONDecodeError, TypeError, ValueError) as e:
+            logger.error("Error loading configuration from file %s: %s", filepath, e)
         return False
 
     def _load_from_env(self) -> None:
@@ -80,8 +82,11 @@ class Config:
                             self._config[key] = json.loads(val)
                         else:
                             self._config[key] = [item.strip() for item in val.split(",") if item.strip()]
-                    except Exception as e:
-                        logger.warning(f"Environment variable '{env_key}' value '{val}' could not be parsed to list: {e}")
+                    except (json.JSONDecodeError, TypeError, ValueError) as e:
+                        logger.warning(
+                            "Environment variable '%s' value '%s' could not be parsed to list: %s",
+                            env_key, val, e,
+                        )
                 else:
                     self._config[key] = val
 
@@ -97,7 +102,7 @@ class Config:
         """
         self._config[key] = value
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Return the entire configuration as a dictionary copy.
         """

--- a/yasinai/core/runtime.py
+++ b/yasinai/core/runtime.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
 from yasinai.core.bootstrap import Bootstrap
 from yasinai.core.config import Config
@@ -20,7 +22,7 @@ class Runtime:
     SHUTTING_DOWN = "SHUTTING_DOWN"
     FAILED = "FAILED"
 
-    def __init__(self, config_defaults: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, config_defaults: dict[str, Any] | None = None) -> None:
         self.config: Config = Config(defaults=config_defaults)
         self.services: ServiceRegistry = ServiceRegistry()
         self.system_info: SystemInfo = SystemInfo(
@@ -30,7 +32,7 @@ class Runtime:
         )
         self.bootstrap_loader: Bootstrap = Bootstrap(self)
         self.state = self.STOPPED
-        self.last_error: Optional[str] = None
+        self.last_error: str | None = None
 
     def start(self) -> None:
         """Start the runtime; repeated starts while ready are harmless."""
@@ -51,7 +53,7 @@ class Runtime:
             self.state = self.FAILED
             self.system_info.status = "failed"
             self._cleanup_services()
-            logger.error("Runtime startup failed", exc_info=True)
+            logger.exception("Runtime startup failed")
             raise RuntimeError(f"Runtime startup failed: {exc}") from exc
 
         logger.info("Core Runtime successfully started and ready.")

--- a/yasinai/core/system.py
+++ b/yasinai/core/system.py
@@ -1,7 +1,7 @@
 import logging
 import platform
 import sys
-from typing import Any, Dict
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ class SystemInfo:
         self.version: str = version
         self.status: str = status
 
-    def get_info(self) -> Dict[str, Any]:
+    def get_info(self) -> dict[str, Any]:
         """
         Get system and environment details.
         """
@@ -30,8 +30,8 @@ class SystemInfo:
                 "os": platform.system(),
                 "architecture": platform.machine(),
             }
-        except Exception as e:
-            logger.error(f"Failed to gather system information: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to gather system information")
             # Return basic fallback information to ensure non-breaking behavior
             return {
                 "app_name": self.app_name,
@@ -50,7 +50,7 @@ class ServiceRegistry:
     """
 
     def __init__(self) -> None:
-        self._services: Dict[str, Any] = {}
+        self._services: dict[str, Any] = {}
 
     def register_service(self, name: str, service: Any, overwrite: bool = False) -> None:
         """
@@ -90,7 +90,7 @@ class ServiceRegistry:
         logger.warning(f"Attempted to unregister non-existent service: '{name}'")
         return False
 
-    def list_services(self) -> Dict[str, Any]:
+    def list_services(self) -> dict[str, Any]:
         """
         Return all registered services.
         """

--- a/yasinai/deployment/docker_manager.py
+++ b/yasinai/deployment/docker_manager.py
@@ -9,7 +9,7 @@ import logging
 import os
 import shutil
 import subprocess
-from typing import Any, Dict
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -102,12 +102,13 @@ class DockerManager:
                     ["docker", "compose", "version"],
                     capture_output=True,
                     text=True,
+                    check=False,  # availability probe — nonzero means compose missing
                 )
                 success = res.returncode == 0
                 logger.debug(f"'docker compose' verification exit code: {res.returncode}")
                 return success
-            except Exception as e:
-                logger.warning(f"Error while invoking 'docker compose version': {e}")
+            except Exception as e:  # noqa: BLE001 — availability probe must not raise
+                logger.warning("Error while invoking 'docker compose version': %s", e)
                 return False
         logger.debug("Docker Compose is not available.")
         return False
@@ -117,7 +118,7 @@ class DockerManager:
         overwrite: bool = False,
         *,
         confirm_overwrite_production: bool = False,
-    ) -> Dict[str, bool]:
+    ) -> dict[str, bool]:
         """
         Ensure Dockerfile and docker-compose.yml exist under ``root_directory``.
 
@@ -184,11 +185,11 @@ class DockerManager:
                 f.write(content)
             logger.info("Wrote %s at: %s", label, path)
             return True
-        except OSError as e:
-            logger.error("Failed to write %s: %s", label, e, exc_info=True)
+        except OSError:
+            logger.exception("Failed to write %s", label)
             return False
 
-    def get_docker_status(self) -> Dict[str, Any]:
+    def get_docker_status(self) -> dict[str, Any]:
         """Get status of docker tools and files."""
         logger.debug("Retrieving Docker deployment status...")
         status = {

--- a/yasinai/deployment/health_check.py
+++ b/yasinai/deployment/health_check.py
@@ -5,7 +5,7 @@ Verifies post-deployment integrity of Core Runtime, CLI, Security Platform, and 
 
 import argparse
 import logging
-from typing import Any, Dict
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -15,12 +15,12 @@ class HealthCheck:
     Performs comprehensive health checks across all integrated platforms.
     """
 
-    def run_all_checks(self) -> Dict[str, Any]:
+    def run_all_checks(self) -> dict[str, Any]:
         """
         Run verification on all platforms and return detailed status.
         """
         logger.info("Running health checks on all platforms...")
-        checks: Dict[str, Dict[str, Any]] = {
+        checks: dict[str, dict[str, Any]] = {
             "runtime": self.check_runtime(),
             "cli": self.check_cli(),
             "security_platform": self.check_security_platform(),
@@ -37,7 +37,7 @@ class HealthCheck:
             "platforms": checks
         }
 
-    def check_runtime(self) -> Dict[str, Any]:
+    def check_runtime(self) -> dict[str, Any]:
         """
         Verify that the Core Runtime can boot and return status.
         """
@@ -56,14 +56,14 @@ class HealthCheck:
                 "details": info
             }
         except Exception as e:
-            logger.error(f"Core Runtime health check: FAILED: {e}", exc_info=True)
+            logger.exception("Core Runtime health check: FAILED")
             return {
                 "success": False,
                 "message": f"Core Runtime verification failed: {e!s}",
                 "details": {}
             }
 
-    def check_cli(self) -> Dict[str, Any]:
+    def check_cli(self) -> dict[str, Any]:
         """
         Verify that the CLI interface is configured and responsive.
         """
@@ -74,8 +74,7 @@ class HealthCheck:
             subcommands = []
             for action in parser._actions:
                 if isinstance(action, argparse._SubParsersAction):
-                    for choice in action.choices:
-                        subcommands.append(choice)
+                    subcommands.extend(action.choices)
 
             success = len(subcommands) > 0
             logger.debug(f"CLI health check: {'OK' if success else 'FAILED'}")
@@ -85,14 +84,14 @@ class HealthCheck:
                 "subcommands_found": subcommands
             }
         except Exception as e:
-            logger.error(f"CLI health check: FAILED: {e}", exc_info=True)
+            logger.exception("CLI health check: FAILED")
             return {
                 "success": False,
                 "message": f"CLI verification failed: {e!s}",
                 "subcommands_found": []
             }
 
-    def check_security_platform(self) -> Dict[str, Any]:
+    def check_security_platform(self) -> dict[str, Any]:
         """
         Verify that Security Platform components are functional.
         """
@@ -120,7 +119,7 @@ class HealthCheck:
                 "encryption_ok": dec_data == "health_check_secret"
             }
         except Exception as e:
-            logger.error(f"Security Platform health check: FAILED: {e}", exc_info=True)
+            logger.exception("Security Platform health check: FAILED")
             return {
                 "success": False,
                 "message": f"Security Platform verification failed: {e!s}",
@@ -128,7 +127,7 @@ class HealthCheck:
                 "encryption_ok": False
             }
 
-    def check_knowledge_platform(self) -> Dict[str, Any]:
+    def check_knowledge_platform(self) -> dict[str, Any]:
         """
         Verify that Knowledge Platform memory and search components are functional.
         """
@@ -154,7 +153,7 @@ class HealthCheck:
                 "search_ok": len(results) > 0
             }
         except Exception as e:
-            logger.error(f"Knowledge Platform health check: FAILED: {e}", exc_info=True)
+            logger.exception("Knowledge Platform health check: FAILED")
             return {
                 "success": False,
                 "message": f"Knowledge Platform verification failed: {e!s}",

--- a/yasinai/deployment/installer.py
+++ b/yasinai/deployment/installer.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import sys
-from typing import Any, Dict, List
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ class Installer:
     def __init__(self, target_directory: str = "."):
         self.target_directory: str = target_directory
 
-    def verify_environment(self) -> Dict[str, Any]:
+    def verify_environment(self) -> dict[str, Any]:
         """
         Verify the system environment meets prerequisites (Python version, write permissions).
         """
@@ -44,7 +44,7 @@ class Installer:
             "target_directory": target_path
         }
 
-    def setup_directories(self) -> List[str]:
+    def setup_directories(self) -> list[str]:
         """
         Create necessary system directories.
         """
@@ -54,25 +54,25 @@ class Installer:
             os.path.join(self.target_directory, "logs"),
             os.path.join(self.target_directory, "config"),
         ]
-        created: List[str] = []
+        created: list[str] = []
         for d in directories:
             if not os.path.exists(d):
                 try:
                     os.makedirs(d, exist_ok=True)
                     created.append(d)
                     logger.info(f"Created directory: {d}")
-                except Exception as e:
-                    logger.error(f"Failed to create directory '{d}': {e}", exc_info=True)
+                except Exception:
+                    logger.exception("Failed to create directory %s", d)
         return created
 
-    def install(self) -> Dict[str, Any]:
+    def install(self) -> dict[str, Any]:
         """
         Execute the full automated setup.
         """
         logger.info("Executing YasinAI local installation...")
         env_status = self.verify_environment()
         if not env_status["success"]:
-            logger.error("Local installation aborted: environment verification failed.")
+            logger.exception("Local installation aborted: environment verification failed.")
             return {
                 "success": False,
                 "message": "Environment verification failed.",
@@ -87,11 +87,11 @@ class Installer:
         if not os.path.exists(config_path):
             try:
                 from yasinai import __version__ as _pkg_version
-            except Exception:
+            except Exception:  # noqa: BLE001 — package may be partially installed
                 try:
                     from importlib.metadata import version as _meta_version
                     _pkg_version = _meta_version("yasinai")
-                except Exception:
+                except Exception:  # noqa: BLE001 — fall back when metadata unavailable
                     _pkg_version = "0.0.0"
             default_config = {
                 "app_name": "YasinAI",
@@ -107,7 +107,7 @@ class Installer:
                 config_created = True
                 logger.info(f"Created default configuration template at: {config_path}")
             except OSError as e:
-                logger.error(f"Failed to create configuration file template at '{config_path}': {e}", exc_info=True)
+                logger.error(f"Failed to create configuration file template at '{config_path}': {e}")
 
         logger.info("YasinAI local installation successfully completed.")
         return {

--- a/yasinai/deployment/package_builder.py
+++ b/yasinai/deployment/package_builder.py
@@ -2,11 +2,12 @@
 Package Builder for YasinAI Deployment System.
 Bundles modules, agents, and plugins into deployable artifacts.
 """
+from __future__ import annotations
 
 import logging
 import os
 import tarfile
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -28,8 +29,8 @@ class PackageBuilder:
         version: str = "1.0.0",
         output_directory: str = "dist/",
         *,
-        include_paths: Optional[List[str]] = None,
-    ) -> Dict[str, Any]:
+        include_paths: list[str] | None = None,
+    ) -> dict[str, Any]:
         """
         Bundle the given paths into a real .tar.gz deployment artifact.
 
@@ -46,7 +47,7 @@ class PackageBuilder:
             os.makedirs(output_directory, exist_ok=True)
             archive_path = os.path.join(output_directory, package_name)
 
-            files_included: List[str] = []
+            files_included: list[str] = []
             with tarfile.open(archive_path, "w:gz") as tar:
                 for path in paths_to_include:
                     if not os.path.exists(path):
@@ -65,8 +66,8 @@ class PackageBuilder:
             }
             logger.info(f"Package successfully built: {archive_path}")
             return result
-        except Exception as e:
-            logger.error(f"Failed to build package '{name}': {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to build package '{name}'")
             return {
                 "success": False,
                 "package_name": "",

--- a/yasinai/integration/agent_client.py
+++ b/yasinai/integration/agent_client.py
@@ -9,7 +9,7 @@ This module is a reference implementation / smoke harness for that boundary.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from yasinai.contracts.generation import GenerationRequest, GenerationResult
 from yasinai.contracts.knowledge import (
@@ -34,9 +34,9 @@ class YasinAgentClient:
     def __init__(
         self,
         *,
-        knowledge: Optional[KnowledgeService] = None,
-        generation: Optional[GenerationService] = None,
-        rag: Optional[RagService] = None,
+        knowledge: KnowledgeService | None = None,
+        generation: GenerationService | None = None,
+        rag: RagService | None = None,
     ) -> None:
         self._knowledge = knowledge if knowledge is not None else KnowledgeService()
         self._generation = (
@@ -54,9 +54,9 @@ class YasinAgentClient:
         self,
         content: Any,
         *,
-        key: Optional[str] = None,
+        key: str | None = None,
         long_term: bool = False,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
     ) -> MemoryResponse:
         mem_type = MemoryType.LONG_TERM if long_term else MemoryType.SHORT_TERM
         return self._knowledge.memory(
@@ -72,9 +72,9 @@ class YasinAgentClient:
     def recall(
         self,
         *,
-        key: Optional[str] = None,
+        key: str | None = None,
         long_term: bool = False,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> MemoryResponse:
         mem_type = MemoryType.LONG_TERM if long_term else MemoryType.SHORT_TERM
         return self._knowledge.memory(
@@ -98,7 +98,7 @@ class YasinAgentClient:
         )
 
     def index_document(
-        self, doc_id: str, text: str, metadata: Optional[Dict[str, Any]] = None
+        self, doc_id: str, text: str, metadata: dict[str, Any] | None = None
     ) -> None:
         self._knowledge.add_document(doc_id, text, metadata or {})
 
@@ -108,9 +108,9 @@ class YasinAgentClient:
         self,
         prompt: str,
         *,
-        system_prompt: Optional[str] = None,
-        model: Optional[str] = None,
-        provider: Optional[str] = None,
+        system_prompt: str | None = None,
+        model: str | None = None,
+        provider: str | None = None,
         max_tokens: int = 1024,
         temperature: float = 0.7,
     ) -> GenerationResult:
@@ -133,8 +133,8 @@ class YasinAgentClient:
         *,
         top_k: int = 5,
         include_memory: bool = True,
-        model: Optional[str] = None,
-        provider: Optional[str] = None,
+        model: str | None = None,
+        provider: str | None = None,
     ) -> RagResult:
         return self._rag.run(
             RagRequest(
@@ -146,6 +146,6 @@ class YasinAgentClient:
             )
         )
 
-    def capabilities(self) -> List[str]:
+    def capabilities(self) -> list[str]:
         """Stable capability names Yasin-Agent may depend on."""
         return ["memory", "knowledge", "generation", "rag"]

--- a/yasinai/integration/cli_client.py
+++ b/yasinai/integration/cli_client.py
@@ -6,7 +6,7 @@ yasinai.contracts / yasinai.services (not knowledge_platform directly).
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from yasinai.contracts.generation import GenerationRequest, GenerationResult
 from yasinai.contracts.knowledge import (
@@ -26,9 +26,9 @@ class YasinCLIClient:
     def __init__(
         self,
         *,
-        knowledge: Optional[KnowledgeService] = None,
-        generation: Optional[GenerationService] = None,
-        rag: Optional[RagService] = None,
+        knowledge: KnowledgeService | None = None,
+        generation: GenerationService | None = None,
+        rag: RagService | None = None,
     ) -> None:
         self._knowledge = knowledge if knowledge is not None else KnowledgeService()
         self._generation = (
@@ -73,8 +73,8 @@ class YasinCLIClient:
 
     def format_search_results(
         self, result: KnowledgeResult, *, threshold: float = 0.0
-    ) -> List[Dict[str, Any]]:
-        rows: List[Dict[str, Any]] = []
+    ) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
         for entry in result.entries or []:
             score = float(entry.score or 0.0)
             if score < threshold and threshold > 0:
@@ -98,5 +98,5 @@ class YasinCLIClient:
             )
         return rows
 
-    def capabilities(self) -> List[str]:
+    def capabilities(self) -> list[str]:
         return ["memory_search", "generation", "rag"]

--- a/yasinai/integration/feed_client.py
+++ b/yasinai/integration/feed_client.py
@@ -6,8 +6,6 @@ hints and short summaries via contracts/services only.
 """
 from __future__ import annotations
 
-from typing import List, Optional
-
 from yasinai.contracts.generation import GenerationRequest, GenerationResult
 from yasinai.contracts.knowledge import (
     KnowledgeQuery,
@@ -24,8 +22,8 @@ class YasinFeedClient:
     def __init__(
         self,
         *,
-        knowledge: Optional[KnowledgeService] = None,
-        generation: Optional[GenerationService] = None,
+        knowledge: KnowledgeService | None = None,
+        generation: GenerationService | None = None,
     ) -> None:
         self._knowledge = knowledge if knowledge is not None else KnowledgeService()
         self._generation = (
@@ -48,7 +46,7 @@ class YasinFeedClient:
         self,
         text: str,
         *,
-        provider: Optional[str] = None,
+        provider: str | None = None,
         max_tokens: int = 256,
     ) -> GenerationResult:
         return self._generation.generate(
@@ -60,5 +58,5 @@ class YasinFeedClient:
             )
         )
 
-    def capabilities(self) -> List[str]:
+    def capabilities(self) -> list[str]:
         return ["rank", "index_item", "summarize_card"]

--- a/yasinai/integration/hub_client.py
+++ b/yasinai/integration/hub_client.py
@@ -7,7 +7,7 @@ Hub telemetry export.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from observability.metrics import MetricsRegistry
 from yasinai.contracts.generation import GenerationRequest, GenerationResult
@@ -30,10 +30,10 @@ class YasinHubClient:
     def __init__(
         self,
         *,
-        knowledge: Optional[KnowledgeService] = None,
-        generation: Optional[GenerationService] = None,
-        rag: Optional[RagService] = None,
-        metrics: Optional[MetricsRegistry] = None,
+        knowledge: KnowledgeService | None = None,
+        generation: GenerationService | None = None,
+        rag: RagService | None = None,
+        metrics: MetricsRegistry | None = None,
     ) -> None:
         self._knowledge = knowledge if knowledge is not None else KnowledgeService()
         self._generation = (
@@ -50,9 +50,9 @@ class YasinHubClient:
         self,
         prompt: str,
         *,
-        model: Optional[str] = None,
-        provider: Optional[str] = None,
-        system_prompt: Optional[str] = None,
+        model: str | None = None,
+        provider: str | None = None,
+        system_prompt: str | None = None,
         max_tokens: int = 1024,
         temperature: float = 0.7,
     ) -> GenerationResult:
@@ -101,7 +101,7 @@ class YasinHubClient:
         *,
         top_k: int = 5,
         include_memory: bool = False,
-        provider: Optional[str] = None,
+        provider: str | None = None,
     ) -> RagResult:
         self._metrics.counter("hub.rag.requests").inc()
         from time import monotonic
@@ -122,7 +122,7 @@ class YasinHubClient:
             self._metrics.counter("hub.rag.errors").inc()
         return result
 
-    def metrics_snapshot(self) -> Dict[str, Any]:
+    def metrics_snapshot(self) -> dict[str, Any]:
         """Export counters/timers for YasinHub control-plane telemetry."""
         return self._metrics.snapshot()
 

--- a/yasinai/integration/press_client.py
+++ b/yasinai/integration/press_client.py
@@ -6,8 +6,6 @@ draft assistance and grounded fact lookup via contracts/services only.
 """
 from __future__ import annotations
 
-from typing import List, Optional
-
 from yasinai.contracts.generation import GenerationRequest, GenerationResult
 from yasinai.contracts.rag import RagRequest, RagResult
 from yasinai.services.generation_service import GenerationService
@@ -21,9 +19,9 @@ class YasinPressClient:
     def __init__(
         self,
         *,
-        knowledge: Optional[KnowledgeService] = None,
-        generation: Optional[GenerationService] = None,
-        rag: Optional[RagService] = None,
+        knowledge: KnowledgeService | None = None,
+        generation: GenerationService | None = None,
+        rag: RagService | None = None,
     ) -> None:
         self._knowledge = knowledge if knowledge is not None else KnowledgeService()
         self._generation = (
@@ -39,7 +37,7 @@ class YasinPressClient:
         self,
         brief: str,
         *,
-        provider: Optional[str] = None,
+        provider: str | None = None,
         max_tokens: int = 1024,
     ) -> GenerationResult:
         return self._generation.generate(
@@ -56,7 +54,7 @@ class YasinPressClient:
         question: str,
         *,
         top_k: int = 5,
-        provider: Optional[str] = None,
+        provider: str | None = None,
     ) -> RagResult:
         return self._rag.run(
             RagRequest(
@@ -71,5 +69,5 @@ class YasinPressClient:
     def index_source(self, source_id: str, text: str) -> None:
         self._knowledge.add_document(source_id, text)
 
-    def capabilities(self) -> List[str]:
+    def capabilities(self) -> list[str]:
         return ["draft", "research", "index_source"]

--- a/yasinai/integration/relay_client.py
+++ b/yasinai/integration/relay_client.py
@@ -6,8 +6,6 @@ enrichment (generation / RAG) without importing internal platforms.
 """
 from __future__ import annotations
 
-from typing import Optional
-
 from yasinai.contracts.generation import GenerationRequest, GenerationResult
 from yasinai.contracts.rag import RagRequest, RagResult
 from yasinai.services.generation_service import GenerationService
@@ -20,8 +18,8 @@ class YasinRelayClient:
     def __init__(
         self,
         *,
-        generation: Optional[GenerationService] = None,
-        rag: Optional[RagService] = None,
+        generation: GenerationService | None = None,
+        rag: RagService | None = None,
     ) -> None:
         self._generation = (
             generation if generation is not None else GenerationService()
@@ -33,8 +31,8 @@ class YasinRelayClient:
         payload: str,
         *,
         instruction: str = "Summarize for relay delivery.",
-        provider: Optional[str] = None,
-        model: Optional[str] = None,
+        provider: str | None = None,
+        model: str | None = None,
     ) -> GenerationResult:
         prompt = f"{instruction}\n\nPayload:\n{payload}"
         return self._generation.generate(
@@ -51,7 +49,7 @@ class YasinRelayClient:
         query: str,
         *,
         top_k: int = 3,
-        provider: Optional[str] = None,
+        provider: str | None = None,
     ) -> RagResult:
         return self._rag.run(
             RagRequest(query=query, top_k=top_k, provider=provider, include_memory=False)

--- a/yasinai/providers/anthropic_provider.py
+++ b/yasinai/providers/anthropic_provider.py
@@ -15,7 +15,7 @@ import logging
 import os
 import urllib.error
 import urllib.request
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable
 
 from yasinai.providers.base import (
     GenerationRequest,
@@ -26,7 +26,7 @@ from yasinai.providers.base import (
     ProviderInfo,
 )
 
-HttpTransport = Callable[[str, Dict[str, str], Dict[str, Any]], Dict[str, Any]]
+HttpTransport = Callable[[str, dict[str, str], dict[str, Any]], dict[str, Any]]
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +36,8 @@ ANTHROPIC_VERSION = "2023-06-01"
 
 
 def _default_http_transport(
-    url: str, headers: Dict[str, str], body: Dict[str, Any]
-) -> Dict[str, Any]:
+    url: str, headers: dict[str, str], body: dict[str, Any]
+) -> dict[str, Any]:
     data = json.dumps(body).encode("utf-8")
     req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     try:
@@ -70,17 +70,17 @@ class AnthropicProvider(ProviderBase):
     def __init__(
         self,
         *,
-        api_key: Optional[str] = None,
-        base_url: Optional[str] = None,
+        api_key: str | None = None,
+        base_url: str | None = None,
         default_model: str = DEFAULT_MODEL,
-        transport: Optional[HttpTransport] = None,
+        transport: HttpTransport | None = None,
     ) -> None:
         self._api_key_override = api_key
         self._base_url = (base_url or DEFAULT_BASE_URL).rstrip("/")
         self._default_model = default_model
         self._transport = transport or _default_http_transport
 
-    def _api_key(self) -> Optional[str]:
+    def _api_key(self) -> str | None:
         return self._api_key_override or os.environ.get("ANTHROPIC_API_KEY")
 
     @property
@@ -114,7 +114,7 @@ class AnthropicProvider(ProviderBase):
                 retryable=False,
             )
         model = request.model or self._default_model
-        body: Dict[str, Any] = {
+        body: dict[str, Any] = {
             "model": model,
             "max_tokens": request.max_tokens,
             "temperature": request.temperature,

--- a/yasinai/providers/base.py
+++ b/yasinai/providers/base.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 class ProviderCapability(str, Enum):
@@ -33,9 +33,9 @@ class ProviderInfo:
     """Static metadata about a registered provider."""
     name: str
     version: str = "unknown"
-    capabilities: List[ProviderCapability] = field(default_factory=list)
-    model_ids: List[str] = field(default_factory=list)
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    capabilities: list[ProviderCapability] = field(default_factory=list)
+    model_ids: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -46,12 +46,12 @@ class GenerationRequest:
     provider-specific hints that are not part of the public contract.
     """
     prompt: str
-    model: Optional[str] = None
+    model: str | None = None
     max_tokens: int = 1024
     temperature: float = 0.7
-    system_prompt: Optional[str] = None
-    stop_sequences: List[str] = field(default_factory=list)
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    system_prompt: str | None = None
+    stop_sequences: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not self.prompt:
@@ -72,8 +72,8 @@ class GenerationResponse:
     provider: str
     input_tokens: int = 0
     output_tokens: int = 0
-    finish_reason: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    finish_reason: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 class ProviderBase(ABC):

--- a/yasinai/providers/local_provider.py
+++ b/yasinai/providers/local_provider.py
@@ -5,8 +5,6 @@ Always available. Useful for tests, CI, and air-gapped environments.
 """
 from __future__ import annotations
 
-from typing import Optional
-
 from yasinai.providers.base import (
     GenerationRequest,
     GenerationResponse,
@@ -21,7 +19,7 @@ class LocalProvider(ProviderBase):
 
     DEFAULT_MODEL = "local-echo-v1"
 
-    def __init__(self, *, model_id: Optional[str] = None) -> None:
+    def __init__(self, *, model_id: str | None = None) -> None:
         self._model_id = model_id or self.DEFAULT_MODEL
 
     @property

--- a/yasinai/providers/openai_provider.py
+++ b/yasinai/providers/openai_provider.py
@@ -16,7 +16,7 @@ import logging
 import os
 import urllib.error
 import urllib.request
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -30,15 +30,15 @@ from yasinai.providers.base import (
 )
 
 # Optional injectable transport: (url, headers, body_dict) -> response_dict
-HttpTransport = Callable[[str, Dict[str, str], Dict[str, Any]], Dict[str, Any]]
+HttpTransport = Callable[[str, dict[str, str], dict[str, Any]], dict[str, Any]]
 
 DEFAULT_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MODEL = "gpt-4o-mini"
 
 
 def _default_http_transport(
-    url: str, headers: Dict[str, str], body: Dict[str, Any]
-) -> Dict[str, Any]:
+    url: str, headers: dict[str, str], body: dict[str, Any]
+) -> dict[str, Any]:
     data = json.dumps(body).encode("utf-8")
     req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     try:
@@ -71,10 +71,10 @@ class OpenAIProvider(ProviderBase):
     def __init__(
         self,
         *,
-        api_key: Optional[str] = None,
-        base_url: Optional[str] = None,
+        api_key: str | None = None,
+        base_url: str | None = None,
         default_model: str = DEFAULT_MODEL,
-        transport: Optional[HttpTransport] = None,
+        transport: HttpTransport | None = None,
     ) -> None:
         # api_key arg is for tests only; production uses env
         self._api_key_override = api_key
@@ -82,7 +82,7 @@ class OpenAIProvider(ProviderBase):
         self._default_model = default_model
         self._transport = transport or _default_http_transport
 
-    def _api_key(self) -> Optional[str]:
+    def _api_key(self) -> str | None:
         return self._api_key_override or os.environ.get("OPENAI_API_KEY")
 
     @property
@@ -123,7 +123,7 @@ class OpenAIProvider(ProviderBase):
             messages.append({"role": "system", "content": request.system_prompt})
         messages.append({"role": "user", "content": request.prompt})
 
-        body: Dict[str, Any] = {
+        body: dict[str, Any] = {
             "model": model,
             "messages": messages,
             "max_tokens": request.max_tokens,

--- a/yasinai/providers/registry.py
+++ b/yasinai/providers/registry.py
@@ -9,9 +9,9 @@ Phase 3: concrete providers register here.
 """
 from __future__ import annotations
 
+import builtins
 import logging
 from threading import Lock
-from typing import Dict, List, Optional
 
 from yasinai.providers.base import ProviderBase, ProviderCapability, ProviderInfo
 
@@ -26,7 +26,7 @@ class ProviderRegistry:
     """Thread-safe registry of provider adapters."""
 
     def __init__(self) -> None:
-        self._providers: Dict[str, ProviderBase] = {}
+        self._providers: dict[str, ProviderBase] = {}
         self._lock = Lock()
 
     def register(self, provider: ProviderBase, *, overwrite: bool = False) -> None:
@@ -47,15 +47,15 @@ class ProviderRegistry:
             self._providers.pop(name, None)
             return existed
 
-    def get(self, name: str) -> Optional[ProviderBase]:
+    def get(self, name: str) -> ProviderBase | None:
         with self._lock:
             return self._providers.get(name)
 
-    def list(self) -> List[ProviderInfo]:
+    def list(self) -> builtins.list[ProviderInfo]:
         with self._lock:
             return [p.info for p in self._providers.values()]
 
-    def for_capability(self, capability: ProviderCapability) -> List[ProviderBase]:
+    def for_capability(self, capability: ProviderCapability) -> builtins.list[ProviderBase]:
         """Return all providers that support a given capability."""
         with self._lock:
             return [
@@ -63,7 +63,7 @@ class ProviderRegistry:
                 if capability in p.info.capabilities
             ]
 
-    def available_for_capability(self, capability: ProviderCapability) -> List[ProviderBase]:
+    def available_for_capability(self, capability: ProviderCapability) -> builtins.list[ProviderBase]:
         """Return providers that support the capability AND report is_available()."""
         return [p for p in self.for_capability(capability) if p.is_available()]
 

--- a/yasinai/providers/router.py
+++ b/yasinai/providers/router.py
@@ -11,7 +11,6 @@ Routing policy:
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 from yasinai.providers.base import ProviderBase, ProviderCapability, ProviderError
 from yasinai.providers.registry import ProviderRegistry
@@ -21,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 class ProviderUnavailableError(ProviderError):
     """Raised when no provider is available for the requested capability."""
-    def __init__(self, capability: ProviderCapability, model: Optional[str] = None) -> None:
+    def __init__(self, capability: ProviderCapability, model: str | None = None) -> None:
         msg = f"No available provider for capability '{capability.value}'"
         if model:
             msg += f" with model hint '{model}'"
@@ -46,7 +45,7 @@ class ProviderRouter:
     def select(
         self,
         capability: ProviderCapability,
-        model: Optional[str] = None,
+        model: str | None = None,
         *,
         allow_fallback: bool = False,
     ) -> ProviderBase:

--- a/yasinai/services/generation_service.py
+++ b/yasinai/services/generation_service.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import List, Optional
 
 from yasinai.contracts.base import CapabilityMetadata
 from yasinai.contracts.generation import GenerationRequest, GenerationResult
@@ -36,8 +35,8 @@ class GenerationService:
 
     def __init__(
         self,
-        registry: Optional[ProviderRegistry] = None,
-        router: Optional[ProviderRouter] = None,
+        registry: ProviderRegistry | None = None,
+        router: ProviderRouter | None = None,
         *,
         default_capability: ProviderCapability = ProviderCapability.GENERATION,
         max_retries_per_provider: int = 1,
@@ -80,7 +79,7 @@ class GenerationService:
 
         pinned = bool(request.provider)
         fallbacks_used = 0
-        last_error: Optional[ProviderError] = None
+        last_error: ProviderError | None = None
 
         for candidate in candidates:
             attempt = 0
@@ -135,7 +134,7 @@ class GenerationService:
             ),
         )
 
-    def _candidate_providers(self, request: GenerationRequest) -> List[ProviderBase]:
+    def _candidate_providers(self, request: GenerationRequest) -> list[ProviderBase]:
         """Return an ordered list of providers to try for this request.
 
         A caller-pinned request.provider yields exactly one candidate (no

--- a/yasinai/services/knowledge_service.py
+++ b/yasinai/services/knowledge_service.py
@@ -7,7 +7,7 @@ Consumers import this (or contracts) instead of knowledge_platform.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from yasinai.contracts.base import CapabilityMetadata
 from yasinai.contracts.knowledge import (
@@ -42,10 +42,10 @@ class KnowledgeService:
 
     def __init__(
         self,
-        memory_manager: Optional[MemoryManager] = None,
-        knowledge_graph: Optional[KnowledgeGraph] = None,
-        retriever: Optional[Retriever] = None,
-        reasoner: Optional[KnowledgeReasoner] = None,
+        memory_manager: MemoryManager | None = None,
+        knowledge_graph: KnowledgeGraph | None = None,
+        retriever: Retriever | None = None,
+        reasoner: KnowledgeReasoner | None = None,
     ) -> None:
         self._memory = memory_manager or MemoryManager()
         self._graph = knowledge_graph or KnowledgeGraph()
@@ -208,7 +208,7 @@ class KnowledgeService:
 
     def _query_semantic(self, request: KnowledgeQuery, meta: CapabilityMetadata) -> KnowledgeResult:
         results = self._retriever.retrieve(request.text, limit=request.top_k)  # type: ignore[arg-type]
-        entries: List[KnowledgeEntry] = []
+        entries: list[KnowledgeEntry] = []
         for item in results:
             # Retriever returns dicts or objects depending on implementation
             if isinstance(item, dict):
@@ -257,7 +257,7 @@ class KnowledgeService:
     def _query_reasoning(self, request: KnowledgeQuery, meta: CapabilityMetadata) -> KnowledgeResult:
         if self._reasoner is None:
             self._reasoner = KnowledgeReasoner(self._graph)
-        results: List[Any] = []
+        results: list[Any] = []
         # Prefer transitive deduction when a relation is supplied
         if request.relation and hasattr(self._reasoner, "deduce_transitive_relations"):
             try:
@@ -290,7 +290,7 @@ class KnowledgeService:
     # Convenience helpers used by tests / internal callers
     # ------------------------------------------------------------------
 
-    def add_document(self, doc_id: str, text: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    def add_document(self, doc_id: str, text: str, metadata: dict[str, Any] | None = None) -> None:
         """Index a document into the semantic retriever."""
         self._retriever.add_document(doc_id, text, metadata or {})
 

--- a/yasinai/services/rag_service.py
+++ b/yasinai/services/rag_service.py
@@ -7,7 +7,6 @@ and GenerationService. No provider SDKs imported here.
 from __future__ import annotations
 
 import logging
-from typing import List, Optional
 
 from yasinai.contracts.base import CapabilityMetadata
 from yasinai.contracts.generation import GenerationRequest
@@ -34,8 +33,8 @@ class RagService:
 
     def __init__(
         self,
-        knowledge: Optional[KnowledgeService] = None,
-        generation: Optional[GenerationService] = None,
+        knowledge: KnowledgeService | None = None,
+        generation: GenerationService | None = None,
     ) -> None:
         self._knowledge = knowledge if knowledge is not None else KnowledgeService()
         self._generation = generation if generation is not None else GenerationService()
@@ -96,7 +95,7 @@ class RagService:
             logger.exception("RagService.run failed")
             return RagResult(success=False, error=str(exc), meta=meta)
 
-    def _retrieve(self, request: RagRequest) -> List[KnowledgeEntry]:
+    def _retrieve(self, request: RagRequest) -> list[KnowledgeEntry]:
         result = self._knowledge.query(
             KnowledgeQuery(
                 query_type=KnowledgeQueryType.SEMANTIC,
@@ -111,7 +110,7 @@ class RagService:
             return []
         return list(result.entries or [])
 
-    def _memory_context(self, request: RagRequest) -> List[str]:
+    def _memory_context(self, request: RagRequest) -> list[str]:
         resp = self._knowledge.memory(
             MemoryRequest(
                 operation="retrieve",
@@ -121,7 +120,7 @@ class RagService:
         )
         if not resp.success:
             return []
-        bits: List[str] = []
+        bits: list[str] = []
         for entry in resp.entries or []:
             bits.append(str(entry.content))
         return bits
@@ -129,10 +128,10 @@ class RagService:
     @staticmethod
     def _build_prompt(
         request: RagRequest,
-        sources: List[KnowledgeEntry],
-        memory_bits: List[str],
+        sources: list[KnowledgeEntry],
+        memory_bits: list[str],
     ) -> str:
-        sections: List[str] = []
+        sections: list[str] = []
         if sources:
             chunks = []
             for i, src in enumerate(sources, start=1):


### PR DESCRIPTION
## Closes #116

Clears the full pre-existing Ruff backlog (594 → 0) and makes the CI lint job **blocking**.

### Batches
- Typing modernization: UP006/UP045/UP035/FA100 (+ import cleanup)
- G201 → `logger.exception`; TRY401 redundant exception in messages removed
- F841, SIM117, SIM102, RUF012 (ClassVar), PLW1510 (`check=False`), PERF402, B017, RUF013
- Intentional `# noqa: BLE001` only where probes/facades must not raise

### CI
- Removed `continue-on-error: true` from Ruff step in `.github/workflows/ci.yml`

### Tests
- **296 passed** locally
- `ruff check .` clean