### PR TITLE
chore: dedupe Docker CI — docker-build.yml tag/manual only (#119)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,10 +1,13 @@
 name: Docker Build & Smoke Test
 
+# Manual/tag release path only. PR and main push Docker smoke is owned by
+# ci.yml (`docker` job) to avoid duplicate image builds on every push.
+
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
+  push:
+    tags:
+      - "v*"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Closes #119

**Decision:** Keep Docker smoke in `ci.yml` for PR/main push. Restrict `docker-build.yml` to `workflow_dispatch` + version tags (`v*`) so every push does not build the image twice.