### PR TITLE
release: v1.1.4 — final audit fixes on release line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [1.1.4] - 2026-08-15
+
+### Fixed
+- Final audit gaps: preserve requested model across provider fallback; redact internal exceptions from GenerationResult/RagResult errors; PackageBuilder path-traversal guard (#124)
+
 ## [1.1.3] - 2026-08-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ According to YASIN-DOCS ADR-001, Yasin-AI is the Canonical AI Capability Platfor
 - **YasinCLI**: Unified user-facing command surface. (The CLI in `yasinai/cli/` is a local diagnostic helper; the unified command interface is owned by YasinCLI).
 - **YasinRelay / YasinFeed / YasinPress**: Domain, content, and business pipelines.
 
-**Current release: v1.1.3**
+**Current release: v1.1.4**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
@@ -17,7 +17,7 @@ According to YASIN-DOCS ADR-001, Yasin-AI is the Canonical AI Capability Platfor
 
 Yasin-AI has completed its Phase 2.2 architecture reconciliation.
 
-- Reconciled version: **v1.1.3**
+- Reconciled version: **v1.1.4**
 - Security audit: completed
 - Release candidate verification: completed
 - Performance/reliability baseline: completed
@@ -113,7 +113,7 @@ Container deployments should additionally verify the production compose profile 
 
 ## Release history
 
-- **v1.1.3** — Current production release (P1/P2 audit fixes + CI hardening) (includes Docker hardening + persistent storage + Python contract fixes)
+- **v1.1.4** — Current production release (P1/P2 audit fixes + CI hardening) (includes Docker hardening + persistent storage + Python contract fixes)
 - **v1.1.1** — Phases 2–5 complete (contracts, providers, services, ecosystem integration)
 - **v1.1.0** — Maintenance baseline (aligned in Phase 2.2)
 - **v1.0.0** — First production release

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,7 +1,7 @@
 # YasinAI Release Checklist
 
 Version:
-v1.1.3
+v1.1.4
 
 Status:
 Passed
@@ -258,7 +258,7 @@ Before every release:
 Release Status
 
 Version:
-1.1.3
+1.1.4
 
 Project:
 YasinAI

--- a/api_service/app.py
+++ b/api_service/app.py
@@ -20,7 +20,7 @@ Handler = Callable[[Mapping[str, Any]], Mapping[str, Any]]
 @dataclass
 class APIService:
     name: str = "yasinai"
-    version: str = "1.1.3"
+    version: str = "1.1.4"
     _routes: dict[str, Handler] | None = None
 
     def __post_init__(self) -> None:
@@ -68,5 +68,5 @@ class APIService:
         return path
 
 
-def create_service(name: str = "yasinai", version: str = "1.1.3") -> APIService:
+def create_service(name: str = "yasinai", version: str = "1.1.4") -> APIService:
     return APIService(name=name, version=version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yasinai"
-version = "1.1.3"
+version = "1.1.4"
 description = "YasinAI Modular AI Platform"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -74,7 +74,7 @@ def test_observability_context_defaults():
 def test_capability_metadata_defaults():
     meta = CapabilityMetadata(capability="memory")
     assert meta.contract_version == "v1"
-    assert meta.platform_version == "1.1.3"
+    assert meta.platform_version == "1.1.4"
     assert meta.provider is None
 
 

--- a/tests/test_production_readiness.py
+++ b/tests/test_production_readiness.py
@@ -8,9 +8,9 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_version_sources_aligned():
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    assert 'version = "1.1.3"' in pyproject
+    assert 'version = "1.1.4"' in pyproject
     init = (ROOT / "yasinai" / "__init__.py").read_text(encoding="utf-8")
-    assert "1.1.3" in init
+    assert "1.1.4" in init
 
 
 def test_phase3_capability_modules_present():
@@ -69,7 +69,7 @@ def test_ci_coverage_gate_configured():
 
 def test_release_checklist_mentions_phase_gates():
     text = (ROOT / "RELEASE_CHECKLIST.md").read_text(encoding="utf-8")
-    assert "v1.1.3" in text
+    assert "v1.1.4" in text
     assert any(token in text for token in ("Provider", "Generation", "RAG", "Integration", "Phase 5"))
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -12,7 +12,7 @@ from yasinai.core.system import ServiceRegistry, SystemInfo
 def test_config_defaults():
     config = Config()
     assert config.get("app_name") == "YasinAI"
-    assert config.get("version") == "1.1.3"
+    assert config.get("version") == "1.1.4"
     assert config.get("debug") is False
     assert config.get("modules") == []
 

--- a/yasinai/__init__.py
+++ b/yasinai/__init__.py
@@ -1,3 +1,3 @@
 # YasinAI Package
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"

--- a/yasinai/cli/main.py
+++ b/yasinai/cli/main.py
@@ -383,7 +383,7 @@ def create_parser() -> argparse.ArgumentParser:
 
     package_build_parser = package_subparsers.add_parser("build", help="Build deployment artifacts", parents=[parent_parser])
     package_build_parser.add_argument("--output", default="dist/", help="Output directory")
-    package_build_parser.add_argument("--version", default="1.1.3", help="Target package version")
+    package_build_parser.add_argument("--version", default="1.1.4", help="Target package version")
     package_build_parser.set_defaults(func=handle_package_build)
 
     # 6. 'serve' command

--- a/yasinai/contracts/base.py
+++ b/yasinai/contracts/base.py
@@ -52,5 +52,5 @@ class CapabilityMetadata:
 
     capability: str
     contract_version: str = "v1"
-    platform_version: str = "1.1.3"
+    platform_version: str = "1.1.4"
     provider: str | None = None

--- a/yasinai/core/config.py
+++ b/yasinai/core/config.py
@@ -21,7 +21,7 @@ class Config:
         """
         self._config: dict[str, Any] = {
             "app_name": "YasinAI",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "environment": "production",
             "debug": False,
             "modules": []

--- a/yasinai/core/runtime.py
+++ b/yasinai/core/runtime.py
@@ -27,7 +27,7 @@ class Runtime:
         self.services: ServiceRegistry = ServiceRegistry()
         self.system_info: SystemInfo = SystemInfo(
             app_name=self.config.get("app_name", "YasinAI"),
-            version=self.config.get("version", "1.1.3"),
+            version=self.config.get("version", "1.1.4"),
             status="inactive",
         )
         self.bootstrap_loader: Bootstrap = Bootstrap(self)

--- a/yasinai/core/system.py
+++ b/yasinai/core/system.py
@@ -11,7 +11,7 @@ class SystemInfo:
     Provides key information about the running YasinAI system and its environment.
     """
 
-    def __init__(self, app_name: str = "YasinAI", version: str = "1.1.3", status: str = "unknown") -> None:
+    def __init__(self, app_name: str = "YasinAI", version: str = "1.1.4", status: str = "unknown") -> None:
         self.app_name: str = app_name
         self.version: str = version
         self.status: str = status


### PR DESCRIPTION
## Release v1.1.4

Includes #124 final audit gaps on top of v1.1.3.
301 tests passed locally.