### PR TITLE
fix: unify security CLI with canonical scanner

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,269 +1,86 @@
 # YasinAI Release Checklist
 
-Version:
-v1.1.4
+Version: `v1.1.4`
 
-Status:
-Passed
+Status: Release Candidate — pending final CI verification
 
 ---
 
-# 1. Repository
+## Repository and source
 
-- [x] Repository name is correct
-- [x] Default branch is main
-- [x] Repository description updated
-- [x] Topics added
-- [x] README.md exists
-- [x] MASTER_PLAN.md exists
-- [x] AGENTS.md exists
-- [x] ARCHITECTURE.md exists
-- [x] CHANGELOG.md exists
-- [x] VERSIONING_POLICY.md exists
-- [x] LICENSE exists
+- [x] Repository and default branch verified
+- [x] Version metadata synchronized to `1.1.4`
+- [x] Source syntax/import audit completed
+- [x] No known duplicate security implementation remains on the supported CLI paths
 
----
-
-# 2. Source Code
-
-- [x] No syntax errors
-- [x] No broken imports
-- [x] No duplicate modules
-- [x] No unused packages
-- [x] All packages contain __init__.py
-- [x] Code formatted consistently
-
----
-
-# 3. Runtime
+## Runtime and platform
 
 - [x] Runtime starts successfully
-- [x] Bootstrap works
-- [x] Module registration works
-- [x] Configuration loads
+- [x] Bootstrap and configuration paths verified
+- [x] Agent SDK verified
+- [x] Plugin trust boundary documented
+- [x] Memory and knowledge services verified
+- [x] Package Builder verified
 
----
+## Security
 
-# 4. Developer Platform
+- [x] Authentication and authorization reviewed
+- [x] Encryption and key handling reviewed
+- [x] Provider credentials are environment-only
+- [x] Sensitive provider errors are redacted
+- [x] Repository security scanner is real and CI-backed
+- [x] `yasin security check` uses the canonical `SecurityScanner`
+- [x] `python -m yasinai.cli security check` uses the canonical scanner path
+- [x] No known committed secrets
 
-- [x] Agent SDK works
-- [x] Plugin SDK works
-- [x] Application SDK works
-- [x] CLI works
-- [x] Package Builder works
+## CLI
 
----
+- [x] `yasin status`
+- [x] `yasin agent create`
+- [x] `yasin memory search`
+- [x] `yasin security check`
+- [x] `yasin package build`
 
-# 5. Security Platform
+## Tests and CI
 
-- [x] Identity system verified
-- [x] Authentication verified
-- [x] Authorization verified
-- [x] Token validation verified
-- [x] Encryption verified
-- [x] Hashing verified
-- [x] Key management verified
-- [x] Audit logging verified
-- [x] Threat detection verified
+- [x] Unit/integration test suite defined
+- [x] Python 3.9–3.12 matrix configured
+- [x] Ruff lint gate configured
+- [x] `pip-audit` dependency gate configured
+- [x] Security gate configured
+- [x] Docker build/smoke gate configured
+- [ ] Final CI run on the post-audit commit is green
 
----
+## Documentation
 
-# 6. Knowledge Platform
+- [x] README and architecture documentation reviewed
+- [x] Security documentation reviewed
+- [x] Version references aligned to `1.1.4` where applicable
+- [x] Release notes updated for `v1.1.4`
 
-- [x] Short memory works
-- [x] Long memory works
-- [x] Memory manager works
-- [x] Knowledge Graph works
-- [x] Entity system works
-- [x] Relation system works
-- [x] Triple Store works
-- [x] Semantic Search works
-- [x] Context Engine works
-- [x] Reasoning works
+## Deployment
 
----
+- [x] Dockerfile reviewed
+- [x] Production compose hardening reviewed
+- [x] Non-root container execution configured
+- [x] Production read-only/capability restrictions reviewed
+- [x] Docker smoke test configured
 
-# 7. CLI
+## Release integrity
 
-Verify commands:
+- [x] Release tag `v1.1.4` points to the intended release line
+- [x] Release target is `main`
+- [ ] Publish GitHub Release only after final CI/security/Docker verification
 
-- [x] yasin status
-- [x] yasin agent create
-- [x] yasin memory search
-- [x] yasin security check
-- [x] yasin package build
+## Final approval
 
----
+Do not publish the release while any required CI, security, or Docker gate is failing.
 
-# 8. Tests
+### Release commands
 
-- [x] Unit tests pass
-- [x] Integration tests pass
-- [x] Runtime tests pass
-- [x] Security tests pass
-- [x] Memory tests pass
-- [x] CLI tests pass
+```bash
+git tag -a v1.1.4 -m "v1.1.4 Release"
+git push origin v1.1.4
+```
 
-Command:
-
-pytest
-
----
-
-# 9. Documentation
-
-- [x] README updated
-- [x] Architecture updated
-- [x] Installation guide updated
-- [x] SDK guide updated
-- [x] Security documentation updated
-- [x] API documentation updated
-- [x] Versioning policy documented
-
----
-
-# 10. Deployment
-
-- [x] Dockerfile builds
-- [x] requirements.txt verified
-- [x] Installer verified
-- [x] Health check passes
-
----
-
-# 11. GitHub
-
-- [x] No merge conflicts
-- [x] Working tree clean
-- [x] CHANGELOG updated
-- [x] Version updated
-- [x] Release notes prepared
-
-Commands:
-
-git status
-
-git tag
-
-git log
-
----
-
-# 12. Security Review
-
-Verify that repository DOES NOT contain:
-
-- [x] API Keys
-- [x] Tokens
-- [x] Passwords
-- [x] .env
-- [x] Secrets
-- [x] Backup archives
-- [x] Private certificates
-
----
-
-# 13. Performance
-
-- [x] Startup time acceptable
-- [x] Memory usage checked
-- [x] No obvious bottlenecks
-
----
-
-# 14. Release Build
-
-- [x] Version number correct
-- [x] Tag created
-- [x] GitHub Release prepared
-- [x] Release artifacts generated
-
-Tag:
-
-v1.1.0
-
----
-
-# 15. Final Approval
-
-Before publishing verify:
-
-- [x] Architecture preserved
-- [x] Tests passing
-- [x] Documentation complete
-- [x] Repository clean
-- [x] Security verified
-- [x] Deployment verified
-
----
-
-
----
-
-# 12. Phase 3 — Core AI Platform
-
-- [x] Concrete providers (OpenAI, Anthropic, Local)
-- [x] GenerationService + Generation contracts
-- [x] RagService + RAG contracts
-- [x] Provider credentials from environment only
-
----
-
-# 13. Phase 4 — Ecosystem Integration
-
-- [x] Yasin-Agent integration client + docs
-- [x] YasinHub integration client + metrics
-- [x] YasinCLI integration client (memory search via services)
-- [x] YasinRelay / YasinFeed / YasinPress clients + docs
-
----
-
-# 14. Phase 5 — Production Hardening
-
-- [x] Production deploy profile static gates
-- [x] Plugin trust boundary policy (trusted-only default)
-- [x] Production readiness pytest module
-- [x] CI coverage + pip-audit + security check gates
-
----
-
-# Release Commands
-
-git add .
-
-git commit -m "Release v1.1.0"
-
-git tag -a v1.1.0 -m "v1.1.0 Release"
-
-git push origin main
-
-git push origin v1.1.0
-
----
-
-# Agent Instructions
-
-Before every release:
-
-1. Read MASTER_PLAN.md
-2. Read AGENTS.md
-3. Read VERSIONING_POLICY.md
-4. Read docs/ARCHITECTURE.md
-5. Execute this checklist
-6. Report failures
-7. Do not publish if any critical item fails
-
----
-
-Release Status
-
-Version:
-1.1.4
-
-Project:
-YasinAI
-
-Release:
-Production
-
-End of Checklist
+The tag must remain immutable after publication.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,96 +1,50 @@
 # YasinAI Release Notes
 
-## YasinAI v1.1.0 Release Notes
+## YasinAI v1.1.4
 
-We are pleased to announce the stable maintenance release of **YasinAI (v1.1.0)**.
+YasinAI v1.1.4 is the audited release candidate following the final security, CLI, CI/CD, and documentation hardening pass.
 
-This release focuses on hardening package quality gates, clarifying system architectural boundaries in compliance with the target Yasin Ecosystem design, and establishing standard maintenance procedures.
+### Security and correctness
 
----
+- Unified `security check` CLI execution around the canonical `SecurityScanner` implementation.
+- Removed the simulated/hard-coded security-check result path from the primary CLI handler.
+- Direct module and installed CLI security checks now use the same scanner and result semantics.
+- Preserved provider credential handling and internal-error redaction guarantees.
 
-### 🚀 Key Highlights & Enhancements in v1.1.0
+### Quality gates
 
-- **Dependency Audit Integration**: Automatically scans Python dependencies in the CI workflow to block vulnerabilities.
-- **Architectural Boundary Specification**: Fully documents system layers, inward private module coupling rules, and preferred dependency directions.
-- **Unified Observability Metrics Checks**: Added automated timer and counter tests to cover metric reporting mechanisms.
-- **Platform Packaging Consistency**: Synchronized metadata declarations across the Python ecosystem configs and codebase.
+- Python compatibility matrix: 3.9, 3.10, 3.11, and 3.12.
+- Ruff linting is blocking in CI.
+- Dependency vulnerability scanning uses `pip-audit`.
+- Repository security checks are executed by CI.
+- Docker build and smoke-test validation are part of the release gates.
 
----
+### Release verification
 
-## YasinAI v1.0.0 Release Notes
+- Version: `1.1.4`
+- Release tag: `v1.1.4`
+- Release target: `main`
+- Release should be published only after all required CI/security/Docker checks pass on the final release commit.
 
-We are thrilled to present the first official production release of **YasinAI (v1.0.0)**.
+### Known design limitations
 
-YasinAI is a modular, high-performance, and secure artificial intelligence platform designed to build, run, deploy, and manage advanced AI agents, memory layers, and custom plugins. Built on a clean, modular python architecture, YasinAI offers an ecosystem of independent, robust platforms sitting on a shared core runtime.
+- Plugins are trusted-code extensions and are not sandboxed.
+- Session state is process-local unless an external distributed session store is supplied.
+- External secrets-management and network-policy controls remain deployment concerns.
 
----
+### Verification
 
-### 🚀 Key Highlights & Platforms
+Run the complete project test suite with:
 
-### 1. Core Runtime (`yasinai/core/`)
-- **System Diagnostics & Diagnostics Info**: Full platform environment diagnostics and runtime checks.
-- **Service Registry & Lifecycle Orchestration**: Dynamically manages startup, service mapping, and execution lifecycles.
-- **Dynamic Bootstrap Loading**: Automatic and extensible module loading on boot.
-
-### 2. Developer Platform (`developer_platform/`)
-- **Agent SDK**: Intuitive SDK to scaffold, customize, and configure AI Agents.
-- **Plugin SDK**: Build extensible integrations and connectors to third-party services.
-- **Application SDK & CLI Templates**: Accelerate the development of agentic applications.
-- **Developer Tools**: Bundled with a generator, real-time debugger, and performance profiler.
-
-### 3. Security Platform (`security_platform/`)
-- **Comprehensive Identity & Access Control**: Standardized Identity, Authentication, and Authorization system.
-- **Data Security**: In-transit and at-rest Encryption, secure Key Management, and Hashing utilities.
-- **Vulnerability & Audit Tools**: Audit Logging and proactive Threat Detection algorithms to scan and block malicious patterns.
-
-### 4. Knowledge Platform (`knowledge_platform/`)
-- **Dual Memory Layer**: Integrated Short-Term (working) memory and Long-Term (persistent) memory.
-- **Knowledge Graph**: Advanced semantic Graph Store, Triple Store, and structured relationship parsing.
-- **Semantic Engine**: Natural Language Semantic Search, Context Management, and reasoning pipelines.
-
-### 5. Unified Command Line Interface (CLI)
-Global `yasin` entrypoint supports structured `--json` output and command options:
-- `yasin status`: Check core runtime diagnostics.
-- `yasin agent create`: Scaffolds a new agent using the SDK.
-- `yasin memory search`: Query semantic memory stores.
-- `yasin security check`: Run system audits, permissions validation, and secret/vulnerability scans.
-- `yasin package build`: Build and compile deployable artifacts.
-
-### 6. Deployment System (`yasinai/deployment/`)
-- Fully-featured **Installer**, **Docker Manager**, and **Health Check** subsystems.
-- Production-ready `Dockerfile` and `docker-compose.yml` configurations for containerized setups.
-- Generates deployable artifacts and build outputs seamlessly via `PackageBuilder`.
-
----
-
-### 🛠️ Verification & Quality Assurance
-
-- **Unit and Integration Tests**: 100% pass rate over **79 test cases** (`pytest` suite).
-- **Security Check**: Clean repository state. Zero API Keys, tokens, private keys, `.env` files, or configuration secrets committed.
-- **Linting & Code Style**: Adheres strictly to PEP8, clean modular architecture, clear naming, type-hinting, and self-documenting code.
-
----
-
-### 📦 Getting Started
-
-### Local Setup:
 ```bash
-# Clone the repository
-git clone https://github.com/yusi20006-max/Yasin-AI.git
-cd Yasin-AI
-
-# Install package in editable mode with requirements
-pip install -e .
-```
-
-### Docker Setup:
-```bash
-# Build and run the service
-docker-compose up --build
-```
-
-### Test Suite:
-```bash
-# Verify the entire suite passes
 pytest
 ```
+
+Run the canonical security check with:
+
+```bash
+yasin security check
+python -m yasinai.cli security check
+```
+
+Both commands must report the same scanner-backed result semantics.

--- a/yasinai/cli/main.py
+++ b/yasinai/cli/main.py
@@ -113,7 +113,6 @@ def handle_memory_search(args: argparse.Namespace) -> int:
         search = client.search_memory(query or " ", top_k=limit)
         if not search.success:
             raise RuntimeError(search.error or "memory search failed")
-        # Empty query: show demo corpus (threshold only applies to non-empty queries)
         effective_threshold = 0.0 if not (query or "").strip() else threshold
         results = client.format_search_results(search, threshold=effective_threshold)
 
@@ -145,46 +144,17 @@ def handle_memory_search(args: argparse.Namespace) -> int:
 
 
 def handle_security_check(args: argparse.Namespace) -> int:
-    """
-    Handle the 'yasin security check' command.
-    Simulates security vulnerability scan and audit check.
+    """Run the canonical repository security scanner.
+
+    This handler intentionally delegates to the same implementation used by the
+    installed ``yasin`` security entrypoint so every CLI invocation has one
+    source of truth and cannot report simulated results.
     """
     logger.debug("Executing CLI command: security check")
-
     try:
-        # Simulated check items
-        checks = [
-            {"id": "SEC_001", "name": "Environment Secrets Check", "passed": True, "details": "No plain-text credentials found in codebase."},
-            {"id": "SEC_002", "name": "File Permissions", "passed": True, "details": "Repository files are properly restricted."},
-            {"id": "SEC_003", "name": "Encryption Engines", "passed": True, "details": "SHA-256 and AES configuration validated."},
-            {"id": "SEC_004", "name": "Policy Engine Health", "passed": True, "details": "Role-Based Access Control policies loaded."},
-        ]
-
-        failed_checks = [c for c in checks if not c["passed"]]
-        overall_status = "SECURE" if not failed_checks else "VULNERABLE"
-
-        output = {
-            "status": overall_status,
-            "scanned_items": len(checks),
-            "failed_items": len(failed_checks),
-            "checks": checks
-        }
-
-        if args.json:
-            print(json.dumps(output, indent=2))
-        else:
-            print("=========================================")
-            print("YasinAI Security Platform - Audit Check")
-            print(f"Status: {overall_status}")
-            print("=========================================")
-            for check in checks:
-                status_str = "[ PASS ]" if check["passed"] else "[ FAIL ]"
-                print(f"{status_str} {check['name']}")
-                print(f"         Details: {check['details']}")
-            print("=========================================")
-            print(f"Scan complete. {len(checks)} checks performed.")
-        logger.info("Successfully executed security check.")
-        return 0
+        from yasinai.cli.security_entrypoint import security_check
+        argv = ["--json"] if getattr(args, "json", False) else []
+        return security_check(argv)
     except Exception as e:
         logger.exception("Error checking security")
         print(f"Error checking security: {e}", file=sys.stderr)
@@ -241,7 +211,6 @@ def handle_serve(args: argparse.Namespace) -> int:
     logger.debug("Executing CLI command: serve")
     interval: int = getattr(args, "interval", 300)
 
-    # Validate interval
     if interval <= 0:
         logger.exception("Interval must be a positive integer.")
         print("Error: Interval must be a positive integer.", file=sys.stderr)
@@ -254,7 +223,6 @@ def handle_serve(args: argparse.Namespace) -> int:
         nonlocal stop_flag
         stop_flag = True
 
-    # Register signal handlers
     original_sigint = signal.getsignal(signal.SIGINT)
     original_sigterm = signal.getsignal(signal.SIGTERM)
     signal.signal(signal.SIGINT, signal_handler)
@@ -262,17 +230,11 @@ def handle_serve(args: argparse.Namespace) -> int:
 
     try:
         runtime.start()
-
         health_checker = HealthCheck()
 
         startup_msg = f"YasinAI Core Runtime started in foreground supervisor mode. Health check interval: {interval} seconds."
         if args.json:
-            print(json.dumps({
-                "event": "startup",
-                "status": "running",
-                "interval": interval,
-                "message": startup_msg
-            }))
+            print(json.dumps({"event": "startup", "status": "running", "interval": interval, "message": startup_msg}))
         else:
             print("=========================================")
             print("         YasinAI Foreground Serve        ")
@@ -284,21 +246,13 @@ def handle_serve(args: argparse.Namespace) -> int:
 
         while not stop_flag:
             report = health_checker.run_all_checks()
-
             if args.json:
-                print(json.dumps({
-                    "event": "health_check",
-                    "status": report.get("status"),
-                    "success": report.get("success"),
-                    "timestamp": time.strftime('%Y-%m-%d %H:%M:%S')
-                }))
+                print(json.dumps({"event": "health_check", "status": report.get("status"), "success": report.get("success"), "timestamp": time.strftime('%Y-%m-%d %H:%M:%S')}))
             else:
                 timestamp = time.strftime('%Y-%m-%d %H:%M:%S')
                 print(f"[{timestamp}] Health Check Status: {report.get('status')} (Success: {report.get('success')})")
-
             logger.info(f"Health Check Completed: {report}")
 
-            # Sleep in small increments to be responsive to signals
             slept = 0
             while slept < interval and not stop_flag:
                 time.sleep(1)
@@ -309,31 +263,22 @@ def handle_serve(args: argparse.Namespace) -> int:
         print(f"Error in serve loop: {e}", file=sys.stderr)
         return 1
     finally:
-        # Restore signal handlers
         signal.signal(signal.SIGINT, original_sigint)
         signal.signal(signal.SIGTERM, original_sigterm)
 
         shutdown_msg = "Shutting down YasinAI Core Runtime cleanly..."
         if args.json:
-            print(json.dumps({
-                "event": "shutdown",
-                "status": "stopped",
-                "message": shutdown_msg
-            }))
+            print(json.dumps({"event": "shutdown", "status": "stopped", "message": shutdown_msg}))
         else:
             print(shutdown_msg)
         logger.info(shutdown_msg)
-
         runtime.shutdown()
 
     return 0
 
 
 def create_parser() -> argparse.ArgumentParser:
-    """
-    Creates and configures the argument parser for YasinAI CLI.
-    """
-    # Create a parent parser to share common options like --json
+    """Creates and configures the argument parser for YasinAI CLI."""
     parent_parser = argparse.ArgumentParser(add_help=False)
     parent_parser.add_argument("--json", action="store_true", help="Output results in JSON format")
 
@@ -345,11 +290,9 @@ def create_parser() -> argparse.ArgumentParser:
 
     subparsers = parser.add_subparsers(dest="command", help="Available subcommands")
 
-    # 1. 'status' command
     status_parser = subparsers.add_parser("status", help="Check system status and details", parents=[parent_parser])
     status_parser.set_defaults(func=handle_status)
 
-    # 2. 'agent' command and its 'create' subcommand
     agent_parser = subparsers.add_parser("agent", help="Manage AI Agents", parents=[parent_parser])
     agent_subparsers = agent_parser.add_subparsers(dest="subcommand", help="Agent subcommands")
 
@@ -360,7 +303,6 @@ def create_parser() -> argparse.ArgumentParser:
     agent_create_parser.add_argument("--type", default="standard", help="Type of the agent (e.g. standard, specialist)")
     agent_create_parser.set_defaults(func=handle_agent_create)
 
-    # 3. 'memory' command and its 'search' subcommand
     memory_parser = subparsers.add_parser("memory", help="Manage Knowledge Memory Platform", parents=[parent_parser])
     memory_subparsers = memory_parser.add_subparsers(dest="subcommand", help="Memory subcommands")
 
@@ -370,14 +312,12 @@ def create_parser() -> argparse.ArgumentParser:
     memory_search_parser.add_argument("--threshold", type=float, default=0.7, help="Minimum matching similarity score")
     memory_search_parser.set_defaults(func=handle_memory_search)
 
-    # 4. 'security' command and its 'check' subcommand
     security_parser = subparsers.add_parser("security", help="Manage Security Platform", parents=[parent_parser])
     security_subparsers = security_parser.add_subparsers(dest="subcommand", help="Security subcommands")
 
     security_check_parser = security_subparsers.add_parser("check", help="Run audit and security checks", parents=[parent_parser])
     security_check_parser.set_defaults(func=handle_security_check)
 
-    # 5. 'package' command and its 'build' subcommand
     package_parser = subparsers.add_parser("package", help="Manage Deployment Packaging", parents=[parent_parser])
     package_subparsers = package_parser.add_subparsers(dest="subcommand", help="Package subcommands")
 
@@ -386,7 +326,6 @@ def create_parser() -> argparse.ArgumentParser:
     package_build_parser.add_argument("--version", default="1.1.4", help="Target package version")
     package_build_parser.set_defaults(func=handle_package_build)
 
-    # 6. 'serve' command
     serve_parser = subparsers.add_parser("serve", help="Keep Core Runtime alive as a foreground process", parents=[parent_parser])
     serve_parser.add_argument("--interval", type=int, default=300, help="Periodic health-check interval in seconds")
     serve_parser.set_defaults(func=handle_serve)
@@ -395,9 +334,7 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> None:
-    """
-    Main CLI entrypoint. Parses command line arguments and executes requested subcommands.
-    """
+    """Main CLI entrypoint. Parses command line arguments and executes requested subcommands."""
     if argv is None:
         argv = sys.argv[1:]
 
@@ -408,9 +345,7 @@ def main(argv: list[str] | None = None) -> None:
         parser.print_help()
         sys.exit(0)
 
-    # For commands with nested subcommands, ensure subcommand is provided
     if args.command in ("agent", "memory", "security", "package") and not getattr(args, "subcommand", None):
-        # Print subcommand help
         sub_parsers_actions = [
             action for action in parser._subparsers._actions
             if isinstance(action, argparse._SubParsersAction)
@@ -424,7 +359,6 @@ def main(argv: list[str] | None = None) -> None:
         sys.exit(0)
 
     if hasattr(args, "func"):
-        # Propagate the top-level --json option to nested args if not present
         if args.json and not hasattr(args, "json"):
             args.json = True
         exit_code: int = args.func(args)

--- a/yasinai/cli/security_entrypoint.py
+++ b/yasinai/cli/security_entrypoint.py
@@ -8,15 +8,28 @@ import sys
 
 
 def security_check(argv: list[str]) -> int:
+    """Run the canonical scanner with a stable CLI presentation.
+
+    All security decisions and values come from ``SecurityScanner``.  The
+    ``checks`` compatibility field and legacy heading are presentation-only;
+    they never contain hard-coded pass/fail results.
+    """
     from security_platform.scanner import SecurityScanner
 
     json_output = "--json" in argv
     report = SecurityScanner().scan()
+
+    # Keep the JSON contract used by existing consumers while making the
+    # canonical scanner report the sole source of truth.  The compatibility
+    # list is derived directly from real findings and intentionally contains
+    # no synthetic security result.
+    report["checks"] = report["findings"][:4]
+
     if json_output:
         print(json.dumps(report, indent=2))
     else:
         print("=========================================")
-        print("YasinAI Security Platform - Real Audit")
+        print("YasinAI Security Platform - Audit Check")
         print(f"Status: {report['status']}")
         print("=========================================")
         for finding in report["findings"]:
@@ -24,6 +37,15 @@ def security_check(argv: list[str]) -> int:
             location = f" ({finding['path']})" if finding.get("path") else ""
             print(f"{status} {finding['name']} [{finding['severity']}]{location}")
             print(f"         Details: {finding['details']}")
+        # Backward-compatible human-readable alias for the canonical secret
+        # scan. It is printed only from the actual scanner result.
+        secret_finding = next(
+            (item for item in report["findings"] if item["id"] == "SEC_SECRET_001"),
+            None,
+        )
+        if secret_finding is not None:
+            status = "[ PASS ]" if secret_finding["passed"] else "[ FAIL ]"
+            print(f"{status} Environment Secrets Check (canonical repository secret scan)")
         print("=========================================")
         print(f"Scan complete. {report['scanned_items']} checks performed.")
     return 0 if report["failed_items"] == 0 else 1

--- a/yasinai/cli/security_entrypoint.py
+++ b/yasinai/cli/security_entrypoint.py
@@ -7,48 +7,62 @@ import json
 import sys
 
 
+def _finding_id(finding: dict) -> str | None:
+    """Return a finding identifier when present, without requiring it."""
+    value = finding.get("id")
+    if value is None:
+        return None
+    return str(value)
+
+
 def security_check(argv: list[str]) -> int:
     """Run the canonical scanner with a stable CLI presentation.
 
-    All security decisions and values come from ``SecurityScanner``.  The
+    All security decisions and values come from ``SecurityScanner``. The
     ``checks`` compatibility field and legacy heading are presentation-only;
-    they never contain hard-coded pass/fail results.
+    they never contain hard-coded pass/fail results. Scanner findings may be
+    represented by older/partial schemas, so presentation must not crash when
+    optional metadata such as ``id`` or ``path`` is absent.
     """
     from security_platform.scanner import SecurityScanner
 
     json_output = "--json" in argv
     report = SecurityScanner().scan()
 
-    # Keep the JSON contract used by existing consumers while making the
-    # canonical scanner report the sole source of truth.  The compatibility
-    # list is derived directly from real findings and intentionally contains
-    # no synthetic security result.
-    report["checks"] = report["findings"][:4]
+    findings = report.get("findings", [])
+    report["checks"] = findings[:4]
 
     if json_output:
         print(json.dumps(report, indent=2))
     else:
         print("=========================================")
         print("YasinAI Security Platform - Audit Check")
-        print(f"Status: {report['status']}")
+        print(f"Status: {report.get('status', 'UNKNOWN')}")
         print("=========================================")
-        for finding in report["findings"]:
-            status = "[ PASS ]" if finding["passed"] else "[ FAIL ]"
+        for finding in findings:
+            passed = bool(finding.get("passed", False))
+            status = "[ PASS ]" if passed else "[ FAIL ]"
+            name = finding.get("name", "Unnamed security check")
+            severity = finding.get("severity", "unknown")
             location = f" ({finding['path']})" if finding.get("path") else ""
-            print(f"{status} {finding['name']} [{finding['severity']}]{location}")
-            print(f"         Details: {finding['details']}")
+            details = finding.get("details", "")
+            print(f"{status} {name} [{severity}]{location}")
+            print(f"         Details: {details}")
+
         # Backward-compatible human-readable alias for the canonical secret
-        # scan. It is printed only from the actual scanner result.
+        # scan. It is printed only from the actual scanner result. Older report
+        # schemas may omit the optional finding id, so lookup must be tolerant.
         secret_finding = next(
-            (item for item in report["findings"] if item["id"] == "SEC_SECRET_001"),
+            (item for item in findings if _finding_id(item) == "SEC_SECRET_001"),
             None,
         )
         if secret_finding is not None:
-            status = "[ PASS ]" if secret_finding["passed"] else "[ FAIL ]"
+            status = "[ PASS ]" if bool(secret_finding.get("passed", False)) else "[ FAIL ]"
             print(f"{status} Environment Secrets Check (canonical repository secret scan)")
         print("=========================================")
-        print(f"Scan complete. {report['scanned_items']} checks performed.")
-    return 0 if report["failed_items"] == 0 else 1
+        print(f"Scan complete. {report.get('scanned_items', len(findings))} checks performed.")
+
+    return 0 if report.get("failed_items", 0) == 0 else 1
 
 
 def main(argv: list[str] | None = None) -> None:


### PR DESCRIPTION
## Audit fix for v1.1.4

Fixes the remaining P1 security-integrity finding identified during the final v1.1.4 audit.

### Changes
- Replace the simulated `handle_security_check` implementation with delegation to `SecurityScanner`.
- Ensure the alternate/module CLI path cannot return hard-coded security results.
- Update v1.1.4 release notes and checklist.

### Verification required
- Full CI matrix
- Ruff
- pip-audit
- Security gate
- Docker build/smoke test
- Regression verification of both security CLI invocation paths
