### PR TITLE
docs: rebaseline v1.1.4 architecture and capability truth

### DIFF
--- a/AI_CAPABILITY_CATALOG.md
+++ b/AI_CAPABILITY_CATALOG.md
@@ -1,236 +1,141 @@
-# Yasin-AI — AI Capability Catalog v1
+# Yasin-AI — AI Capability Catalog v1.1.4
 
-**Phase:** 2.4  
-**Version:** 1.1.0  
-**Date:** 2026-08-14  
-**Authority:** Source-verified against codebase and tests. No capability is listed as IMPLEMENTED unless code and tests both exist.
+**Status:** source-synchronized baseline  
+**Authority:** implementation, tests and release documentation  
+**Last reconciled:** 2026-08-16
 
----
+No capability is classified as IMPLEMENTED merely because it appears in a roadmap.
 
-## Classification Legend
+## Classification
 
 | Status | Meaning |
 |---|---|
-| IMPLEMENTED | Code exists, tests pass, verified in this audit |
-| PARTIAL | Core logic exists but incomplete (missing persistence, error path, or test coverage) |
-| EXPERIMENTAL | Exists in code but no tests, or prototype-quality only |
-| PLANNED | In architecture/docs only; no source implementation |
-| DEPRECATED | Exists but superseded or marked for removal |
+| IMPLEMENTED | Implemented and covered by verification/tests where applicable |
+| PARTIAL | Useful implementation exists but the complete capability contract or coverage is incomplete |
+| EXPERIMENTAL | Exists but is not a stable production contract |
+| PLANNED | No complete implementation in v1.1.4 |
 
----
+## 1. Runtime
 
-## 1. Runtime Platform
-
-| Capability | Status | Module | Evidence |
-|---|---|---|---|
-| Runtime lifecycle (start/bootstrap/init/ready/shutdown) | IMPLEMENTED | `yasinai/core/runtime.py` | `test_runtime.py` |
-| Service registry | IMPLEMENTED | `yasinai/core/system.py` | `test_runtime.py` |
-| Config management | IMPLEMENTED | `yasinai/core/config.py` | `test_runtime.py` |
-| Module bootstrap/discovery | IMPLEMENTED | `yasinai/core/bootstrap.py` | `test_runtime.py` |
-| System info reporting | IMPLEMENTED | `yasinai/core/system.py` | `test_runtime.py` |
-| Provider abstraction / model routing | PLANNED | — | Architecture only (ADR-0007) |
-| Provider registry | PLANNED | — | No source |
-| Model registry | PLANNED | — | No source |
-| Retry / fallback / health policies | PLANNED | — | No source |
-
----
-
-## 2. API / Service Layer
-
-| Capability | Status | Module | Evidence |
-|---|---|---|---|
-| Transport-neutral API service | IMPLEMENTED | `api_service/app.py` | `test_api_service.py` |
-| Route registration and dispatch | IMPLEMENTED | `api_service/app.py` | `test_api_service.py` |
-| Health endpoint | IMPLEMENTED | `api_service/app.py` | `test_api_service.py` |
-| Structured error handling | IMPLEMENTED | `api_service/errors.py` | `test_api_service.py` |
-| HTTP transport adapter | PLANNED | — | No source |
-| gRPC / async transport | PLANNED | — | No source |
-| AI Capability Contract v1 (public SDK) | PLANNED | — | Phase 2.5 scope |
-
----
-
-## 3. Memory
-
-| Capability | Status | Module | Evidence |
-|---|---|---|---|
-| Short-term memory (in-process, FIFO, capacity-bounded) | IMPLEMENTED | `knowledge_platform/memory.py` | `test_knowledge_platform.py` |
-| Long-term memory (SQLite-backed, pluggable store) | IMPLEMENTED | `knowledge_platform/memory.py`, `memory_store.py` | `test_memory_store.py`, `test_knowledge_persistence.py` |
-| Memory manager (orchestrates short + long term) | IMPLEMENTED | `knowledge_platform/memory.py` | `test_knowledge_platform.py` |
-| Consolidation (short → long term) | IMPLEMENTED | `knowledge_platform/memory.py` | `test_knowledge_platform.py` |
-| Conversation memory (multi-turn history) | IMPLEMENTED | `knowledge_platform/context.py` | `test_knowledge_platform.py` |
-| Durable memory isolation per session/agent | PLANNED | — | No source |
-| Memory lifecycle policies (TTL, eviction) | PARTIAL | `memory.py` capacity eviction only | No TTL implementation |
-
----
-
-## 4. Knowledge Platform
-
-| Capability | Status | Module | Evidence |
-|---|---|---|---|
-| Knowledge graph (entities + relations + triples) | IMPLEMENTED | `knowledge_platform/graph.py`, `entity.py`, `relation.py`, `triple_store.py` | `test_knowledge_platform.py` |
-| Graph query engine | IMPLEMENTED | `knowledge_platform/query_engine.py` | `test_knowledge_platform.py` |
-| Rule engine (condition/action rules) | IMPLEMENTED | `knowledge_platform/reasoning.py` | `test_knowledge_platform.py` |
-| Transitive reasoning / deduction | IMPLEMENTED | `knowledge_platform/reasoning.py` | `test_knowledge_platform.py` |
-| Context builder (prompt assembly from history + knowledge) | EXPERIMENTAL | `knowledge_platform/context.py` | Exists, no dedicated test for ContextBuilder |
-| Knowledge persistence (SQLite) | IMPLEMENTED | `knowledge_platform/vector_store.py`, `memory_store.py` | `test_knowledge_persistence.py` |
-
----
-
-## 5. Embeddings & Semantic Search
-
-| Capability | Status | Module | Evidence |
-|---|---|---|---|
-| TF-IDF embedding engine (stdlib only, no external deps) | IMPLEMENTED | `knowledge_platform/semantic_search.py` | `test_knowledge_platform.py` |
-| In-memory vector store | IMPLEMENTED | `knowledge_platform/semantic_search.py` | `test_knowledge_platform.py` |
-| SQLite-backed vector store | IMPLEMENTED | `knowledge_platform/vector_store.py` | `test_knowledge_persistence.py` |
-| Cosine similarity retrieval | IMPLEMENTED | `knowledge_platform/semantic_search.py` | `test_knowledge_platform.py` |
-| Semantic search (fit + query) | IMPLEMENTED | `knowledge_platform/semantic_search.py` | `test_knowledge_platform.py` |
-| Retriever (top-k semantic retrieval) | IMPLEMENTED | `knowledge_platform/semantic_search.py` | `test_knowledge_platform.py` |
-| External embedding provider (OpenAI, etc.) | PLANNED | — | No source |
-| Dense vector search (FAISS/Hnswlib) | PLANNED | — | No source |
-
----
-
-## 6. RAG (Retrieval-Augmented Generation)
-
-| Capability | Status | Module | Evidence |
-|---|---|---|---|
-| Retrieval pipeline (semantic search → context) | PARTIAL | `semantic_search.py` + `context.py` | Components exist but no unified RAG pipeline class |
-| RAG orchestrator | PLANNED | — | No source |
-| Document chunking / indexing | PLANNED | — | No source |
-| Generation with retrieved context | PLANNED | — | No source (no LLM provider connected) |
-
----
-
-## 7. Generation & AI Services
-
-| Capability | Status | Module | Evidence |
-|---|---|---|---|
-| Text generation | PLANNED | — | No LLM provider integration in source |
-| Chat / multi-turn generation | PLANNED | — | No source |
-| Structured output generation | PLANNED | — | No source |
-| Summarization | PLANNED | — | No source |
-| Classification | PLANNED | — | No source |
-| Translation | PLANNED | — | No source |
-| Rewriting | PLANNED | — | No source |
-| Vision (image input) | PLANNED | — | No source |
-| Speech | PLANNED | — | No source |
-
----
-
-## 8. Extensions / Plugins
-
-| Capability | Status | Module | Evidence |
-|---|---|---|---|
-| Plugin spec and registry | IMPLEMENTED | `developer_platform/sdk.py` | `test_developer_platform.py` |
-| Plugin decorator (`@plugin`) | IMPLEMENTED | `developer_platform/sdk.py` | `test_developer_platform.py` |
-| Plugin invocation | IMPLEMENTED | `developer_platform/sdk.py` | `test_developer_platform.py` |
-| Extension contract (cross-repo) | PLANNED | — | No stable public contract yet (Phase 2.5 scope) |
-
----
-
-## 9. Developer Platform / SDK
-
-| Capability | Status | Module | Evidence |
-|---|---|---|---|
-| Agent SDK (create/start/stop/execute) | IMPLEMENTED | `developer_platform/agent.py` | `test_developer_platform.py` |
-| App builder | EXPERIMENTAL | `developer_platform/app.py` | Exists, limited test coverage |
-| Package builder | EXPERIMENTAL | `developer_platform/package_builder.py` | Exists, limited test coverage |
-| Debugger | EXPERIMENTAL | `developer_platform/debugger.py` | Exists, limited test coverage |
-| Profiler | EXPERIMENTAL | `developer_platform/profiler.py` | Exists, limited test coverage |
-| Generator | EXPERIMENTAL | `developer_platform/generator.py` | Exists, limited test coverage |
-| SDK extension point | IMPLEMENTED | `developer_platform/sdk.py` | `test_developer_platform.py` |
-
----
-
-## 10. Observability
-
-| Capability | Status | Module | Evidence |
-|---|---|---|---|
-| Counter (thread-safe) | IMPLEMENTED | `observability/metrics.py` | `test_observability.py` |
-| Timer / duration tracking | IMPLEMENTED | `observability/metrics.py` | `test_observability.py` |
-| Metrics registry + snapshot | IMPLEMENTED | `observability/metrics.py` | `test_observability.py` |
-| `@timed` decorator | IMPLEMENTED | `observability/metrics.py` | `test_observability.py` |
-| Structured logging | PARTIAL | stdlib `logging` used throughout | No structured log formatter/exporter |
-| Distributed tracing | PLANNED | — | No source |
-| Metrics export (Prometheus/OTLP) | PLANNED | — | No source |
-
----
-
-## 11. Security Platform
-
-| Capability | Status | Module | Evidence |
-|---|---|---|---|
-| Identity management | IMPLEMENTED | `security_platform/identity.py` | `test_security_platform.py` |
-| Authentication (PBKDF2, session tokens) | IMPLEMENTED | `security_platform/auth.py` | `test_security_platform.py` |
-| Authorization / RBAC | IMPLEMENTED | `security_platform/authorization.py` | `test_security_platform.py` |
-| Encryption (AES-GCM, Fernet) | IMPLEMENTED | `security_platform/encryption.py` | `test_encryption_regression.py` |
-| Security monitoring | IMPLEMENTED | `security_platform/monitoring.py` | `test_phase1_security_hardening.py` |
-| Security scanner | IMPLEMENTED | `security_platform/scanner.py` | `test_security_scanner.py` |
-| Secrets management (external vault) | PLANNED | — | No source |
-| Provider credential isolation | PLANNED | — | No source |
-
----
-
-## 12. Deployment
-
-| Capability | Status | Module | Evidence |
-|---|---|---|---|
-| Docker manager | IMPLEMENTED | `yasinai/deployment/docker_manager.py` | `test_deployment.py` |
-| Health check | IMPLEMENTED | `yasinai/deployment/health_check.py` | `test_deployment.py` |
-| Installer | IMPLEMENTED | `yasinai/deployment/installer.py` | `test_deployment.py` |
-| Package builder (deployment) | IMPLEMENTED | `yasinai/deployment/package_builder.py` | `test_deployment.py` |
-
----
-
-## 13. CLI
-
-| Capability | Status | Module | Evidence |
-|---|---|---|---|
-| `yasin status` command | IMPLEMENTED | `yasinai/cli/main.py` | `test_cli.py` |
-| `yasin agent create` command | IMPLEMENTED | `yasinai/cli/main.py` | `test_cli.py` |
-| JSON output flag | IMPLEMENTED | `yasinai/cli/main.py` | `test_cli.py` |
-| Security CLI entrypoint | EXPERIMENTAL | `yasinai/cli/security_entrypoint.py` | Exists, minimal test |
-| Ecosystem-wide control (start/stop/restart) | PLANNED | — | YasinCLI scope, not Yasin-AI |
-
----
-
-## Summary
-
-| Status | Count |
+| Capability | Status |
 |---|---|
-| IMPLEMENTED | 46 |
-| PARTIAL | 3 |
-| EXPERIMENTAL | 7 |
-| PLANNED | 28 |
-| DEPRECATED | 0 |
+| Runtime lifecycle/bootstrap/configuration | IMPLEMENTED |
+| Service registration | IMPLEMENTED |
+| Graceful shutdown/state handling | IMPLEMENTED |
 
-### Key Findings
+## 2. Provider and generation layer
 
-1. **Core infrastructure is solid:** Runtime, memory, knowledge graph, semantic search, security, observability, and deployment are all IMPLEMENTED with test coverage.
+| Capability | Status |
+|---|---|
+| Provider abstraction | IMPLEMENTED |
+| OpenAI/Anthropic/Local adapters | IMPLEMENTED |
+| Provider factory | IMPLEMENTED |
+| Generation request/result contracts | IMPLEMENTED |
+| Generation service facade | IMPLEMENTED |
+| Bounded provider retry | IMPLEMENTED |
+| Bounded provider fallback | IMPLEMENTED |
+| Explicit provider/model pinning | IMPLEMENTED |
+| Preservation of explicit model constraints during fallback | IMPLEMENTED |
+| Cost-aware routing | PLANNED |
+| Health-aware load balancing | PLANNED |
+| Automatic multi-node failover | PLANNED |
 
-2. **AI generation is entirely PLANNED:** No LLM provider integration exists yet. The platform is a capable foundation but cannot generate text, chat, or call any model.
+## 3. Knowledge and RAG
 
-3. **RAG is partial:** The retrieval primitives (semantic search, context builder) exist but there is no unified RAG pipeline orchestrator.
+| Capability | Status |
+|---|---|
+| Semantic search / TF-IDF baseline | IMPLEMENTED |
+| Retriever/top-k retrieval | IMPLEMENTED |
+| SQLite vector persistence | IMPLEMENTED |
+| Knowledge graph/triple storage | IMPLEMENTED |
+| Reasoning/deduction primitives | IMPLEMENTED |
+| Context construction | IMPLEMENTED |
+| RAG service/orchestration boundary | IMPLEMENTED |
+| Advanced external embedding backends | PLANNED |
+| Advanced vector indexes | PLANNED |
 
-4. **Provider abstraction is the biggest gap:** Model registry, provider gateway, routing, retry/fallback — all PLANNED. This is the core of Phase 3.
+## 4. Memory
 
-5. **EXPERIMENTAL modules need tests:** `developer_platform/app.py`, `debugger.py`, `profiler.py`, `generator.py` have no meaningful test coverage.
+| Capability | Status |
+|---|---|
+| Short-term memory | IMPLEMENTED |
+| SQLite-backed long-term memory | IMPLEMENTED |
+| Memory manager/consolidation | IMPLEMENTED |
+| Multi-turn conversation memory | IMPLEMENTED |
+| Local persistence with WAL/busy-timeout | IMPLEMENTED |
+| Distributed memory store / HA | PLANNED |
+| Advanced TTL/retention policy engine | PLANNED |
 
-6. **Public AI Capability Contracts do not exist yet** — these are Phase 2.5 scope.
+**Contract boundary:** Knowledge represents information/content about the world or corpus; Memory represents interaction/entity/agent-associated state.
 
----
+## 5. Security
 
-## Capability Contract Gap (feeds Phase 2.5)
+| Capability | Status |
+|---|---|
+| Identity/authentication | IMPLEMENTED |
+| Authorization/RBAC | IMPLEMENTED |
+| AES-GCM/encryption facilities | IMPLEMENTED |
+| Security monitoring/audit | IMPLEMENTED |
+| Repository security scanner | IMPLEMENTED |
+| Input/path safety limits | IMPLEMENTED |
+| Provider credential environment isolation | IMPLEMENTED |
+| Internal error redaction | IMPLEMENTED |
+| Trusted in-process plugin boundary | IMPLEMENTED |
+| Untrusted plugin sandbox | PLANNED |
+| External secrets vault integration | PLANNED |
 
-The following capability families need public contracts defined in Phase 2.5:
+## 6. Developer platform and SDK
 
-- `GenerationRequest / GenerationResponse` (blocked on provider — Phase 3)
-- `EmbeddingRequest / EmbeddingResponse` (retrieval primitives exist, contract missing)
-- `KnowledgeQuery / KnowledgeResult` (graph + search exist, contract missing)
-- `MemoryRequest / MemoryResponse` (memory exists, contract missing)
-- `PluginContract` (SDK exists, cross-repo contract missing)
+| Capability | Status |
+|---|---|
+| Agent SDK contracts | IMPLEMENTED |
+| Plugin/extension contracts | IMPLEMENTED |
+| Application/package tooling | EXPERIMENTAL |
+| Debugger/profiler/generator tooling | EXPERIMENTAL |
+| Cross-repository stable ecosystem contract verification | PARTIAL |
 
----
+## 7. API and observability
 
-*Source-verified: 2026-08-14. Re-audit required after any significant implementation change.*
+| Capability | Status |
+|---|---|
+| Transport-neutral API/service layer | IMPLEMENTED |
+| Structured error handling | IMPLEMENTED |
+| Health checks | IMPLEMENTED |
+| Local counters/timers/metrics snapshots | IMPLEMENTED |
+| Distributed tracing | PLANNED |
+| Prometheus/OTLP export | PLANNED |
+
+## 8. Deployment
+
+| Capability | Status |
+|---|---|
+| Docker manager | IMPLEMENTED |
+| Production Docker hardening | IMPLEMENTED |
+| Health check | IMPLEMENTED |
+| Installer/package builder | IMPLEMENTED |
+| Distributed/HA deployment | PLANNED |
+
+## 9. CLI
+
+| Capability | Status |
+|---|---|
+| Local status/diagnostic commands | IMPLEMENTED |
+| Agent creation helper | IMPLEMENTED |
+| Memory search | IMPLEMENTED |
+| Canonical scanner-backed security check | IMPLEMENTED |
+| Package build command | IMPLEMENTED |
+| Ecosystem-wide control center | PLANNED — YasinCLI ownership |
+
+## 10. Ecosystem contracts
+
+The v1.1.4 platform is suitable for controlled integration, but ecosystem-wide compatibility must be verified at the public contract boundary. Consumers must not depend on private modules, SQLite internals, provider-specific clients, or local CLI implementation details.
+
+Required integration verification:
+
+- Yasin-Agent capability contract tests
+- YasinHub observability contract tests
+- YasinCLI command/SDK boundary tests
+- Relay/Feed/Press integration contract tests
+- architecture-boundary tests preventing private implementation imports
+
+These are integration gates, not evidence that the corresponding advanced ecosystem features are already implemented inside Yasin-AI.

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,262 +1,74 @@
 # YasinAI Project Status
 
-**Project:** YasinAI
+**Current code line:** `v1.1.4`  
+**Status:** Stable foundation / controlled integration  
+**Last reconciled:** 2026-08-16
 
-**Current Version:** 1.1.2
+## Executive Summary
 
-**Status:** Released / Post-release Maintenance
+Yasin-AI is the canonical AI capability platform of the Yasin ecosystem. The v1.1.4 code line contains the hardened runtime, provider abstraction and concrete adapters, bounded retry/fallback, generation and RAG service boundaries, local persistent memory/knowledge, security controls, observability, packaging, CI and production container baseline.
 
-**Last Updated:** 2026-08-14
+It is **not** a distributed HA platform and does **not** sandbox untrusted plugins. Those are intentional, documented future capabilities.
 
----
+## Release State
 
-# Executive Summary
-
-Yasin-AI is the Canonical AI Platform of the Yasin Ecosystem according to **YASIN-DOCS ADR-001**. It is not an isolated standalone AI platform, but a shared service platform providing canonical AI capabilities (embeddings, provider routing, inference, semantic retrieval, RAG, and memory contracts) across all other ecosystem platforms (Yasin-Core, Yasin-Agent, YasinHub, YasinCLI, YasinRelay, YasinFeed, YasinPress).
-
-The architecture is divided into the following local capability platforms:
-- Core Runtime (executes in coordination with Yasin-Core)
-- Developer Platform (exposes AI extension contracts to Yasin-Agent and YasinCLI)
-- Security Platform (hardens the local identity, authorization, and crypto boundaries)
-- Knowledge Platform (runs local semantic search and knowledge graph/RAG capabilities)
-- Deployment System (manages local containerization and installer builds)
-
----
-
-# Version & Release Source of Truth
-
-We clearly delineate the platform's release lines to maintain strict ecosystem alignment:
-
-### CURRENT RELEASE
-- **v1.1.2** — Current production maintenance release (Phases 2–5 complete). Unifies code metadata, dependencies auditing, and architecture documentation.
-
-### HISTORICAL RELEASES
-- **v1.0.0** — First official production release. Established core runtime, SDKs, memory retrieval, and hardened security.
-
-### UNRELEASED / DEVELOPMENT
-- **v1.1.1-dev** — Active development towards addressing subsequent maintenance updates, including Phase 2.3 (Version & Release Consistency) and refactoring namespaces.
-
-### PLANNED FUTURE VERSIONS
-- **v1.2.0** — Planned feature release. Targets Provider Gateway (routing, load-balancing), model registries, and isolated plugin containerization.
-
----
-
-# Overall Progress
-
-| Area | Status |
-|-------|--------|
-| Core Runtime | ✅ Complete |
-| Developer Platform | ✅ Complete |
-| Security Platform | ✅ Complete |
-| Knowledge Platform | ✅ Complete |
-| CLI | ✅ Complete |
-| Deployment | ✅ Complete |
-| Documentation | ✅ Complete |
-| Release Preparation | ✅ Complete |
-| Version Consolidation | ✅ Complete |
-
-Overall Progress:
-
-100%
-
----
-
-# Project Structure
-
-```
-YasinAI/
-
-├── yasinai/
-│
-├── developer_platform/
-│
-├── security_platform/
-│
-├── knowledge_platform/
-│
-├── tests/
-│
-├── MASTER_PLAN.md
-├── AGENTS.md
-├── ARCHITECTURE.md
-├── VERSIONING_POLICY.md
-├── PROJECT_STATUS.md
-├── RELEASE_CHECKLIST.md
-└── README.md
-```
-
----
-
-# Implemented Systems
-
-## Runtime
-
-Status:
-
-Complete (v1.1.0)
-
-Modules:
-
-- Runtime
-- Bootstrap
-- System Manager
-
----
-
-## Developer Platform
-
-Status:
-
-Complete
-
-Modules:
-
-- Agent SDK
-- Plugin SDK
-- Application SDK
-- Generator
-- CLI
-
----
-
-## Security Platform
-
-Status:
-
-Complete
-
-Modules:
-
-- Identity
-- Authentication
-- Authorization
-- Encryption
-- Key Management
-- Audit
-- Threat Detection
-
----
-
-## Knowledge Platform
-
-Status:
-
-Complete
-
-Modules:
-
-- Short Memory
-- Long Memory
-- Knowledge Graph
-- Semantic Search
-- Context Engine
-- Reasoning
-
----
-
-## Deployment
-
-Status:
-
-Complete
-
-Modules:
-
-- Installer
-- Docker
-- Package Builder
-- Health Check
-
----
-
-# Testing Status
-
-| Test Suite | Status | Description |
+| Version | State | Notes |
 |---|---|---|
-| Runtime Tests | ✅ Passed | Verifies config loading, service registry, dynamic bootstrap loading, and state transition flow (`tests/test_runtime.py`). |
-| Unit Tests | ✅ Passed | Comprehensive unit tests across all systems. |
-| Integration Tests | ✅ Passed | Integration flows for all primary modules and APIs verified. |
-| CLI Tests | ✅ Passed | Tests command routing, execution, argument passing, and formatting (`tests/test_cli.py`). |
-| Security Tests | ✅ Passed | Validates encryption, identity management, authentication, and authorization (`tests/test_security_platform.py`). |
-| Memory/Knowledge Platform Tests | ✅ Passed | Validates MemoryManager, KnowledgeGraph, semantic retrieval, context builder, and reasoning (`tests/test_knowledge_platform.py`). |
-| Developer Platform Tests | ✅ Passed | Verifies SDKs, plugin loading, generator, and debugger capabilities (`tests/test_developer_platform.py`). |
-| Deployment Tests | ✅ Passed | Verifies Installer setup, Docker configuration checks, and packaging actions (`tests/test_deployment.py`). |
+| `1.1.4` | Current code line | Audit/correctness/security hardening baseline on `main`. |
+| `1.1.3` | Historical | Provider/RAG/Docker/plugin/input/SQLite/CI hardening. |
+| `1.1.2` | Historical | Packaging, persistence and version-contract fixes. |
+| `1.1.1` | Historical | Contracts, provider/service layer, ecosystem clients and production gates. |
+| `1.1.0` | Historical | Architecture/documentation maintenance baseline. |
+| `1.0.0` | Historical | Initial production baseline. |
 
----
+## Implemented
 
-# Resolved Known Issues
+- Runtime lifecycle, bootstrap and configuration
+- Provider abstraction and OpenAI/Anthropic/Local adapters
+- Provider factory and bounded retry/fallback
+- Explicit provider/model constraints preserved during fallback
+- GenerationService and public request/result contracts
+- RagService and RAG request/result contracts
+- Semantic search, knowledge graph and reasoning
+- SQLite-backed memory/vector persistence with concurrency hardening
+- Authentication, authorization, encryption and security scanner
+- Canonical scanner-backed security CLI
+- Local observability metrics
+- Packaging, installer and production Docker hardening
+- CI matrix, Ruff, pip-audit, security gate and Docker smoke validation
 
-### 1. Pre-existing Test Failures
-- Pre-existing test failures under `tests/test_cli.py` and `tests/test_knowledge_platform.py` detected during Phase 2.1 have been fully resolved in Phase 2.2. The complete test suite now executes with 100% pass rates.
+## Current architecture boundaries
 
-### 2. Documented Version Mismatch
-- The discrepancy between codebase metadata (`1.0.0`) and high-level documentation (`1.1.0`) has been officially resolved. All files have been consolidated to version **1.1.0** in Phase 2.2 and Phase 2.3.
+- **Knowledge:** information/content about the world or corpus.
+- **Memory:** interaction/entity/agent-associated state.
+- **Yasin-Agent:** multi-step agent planning and workflow semantics.
+- **YasinHub:** ecosystem lifecycle and global observability.
+- **YasinCLI:** unified user-facing command surface.
 
----
+## Planned / Not claimed as implemented
 
-# Agent Instructions
+- Cost-aware provider routing
+- Health-aware load balancing
+- Automatic multi-node provider failover
+- Distributed/HA persistence
+- Untrusted plugin sandboxing
+- Advanced inference guardrails
+- Full ecosystem-wide contract verification
 
-When working on this repository:
+## Verification baseline
 
-1. Read MASTER_PLAN.md.
-2. Read AGENTS.md.
-3. Read VERSIONING_POLICY.md.
-4. Read docs/ARCHITECTURE.md.
-5. Read RELEASE_CHECKLIST.md.
-6. Update this file after significant work.
+The v1.1.4 CI gates verify Python 3.9–3.12, Ruff, dependency audit, security checks, tests and Docker build/smoke validation. Release documentation must distinguish CI verification of the current `main` line from immutable historical tags.
 
----
+## Integration readiness
 
-# Change Log
+**READY FOR CONTROLLED INTEGRATION.**
 
-## v1.1.0
+Before ecosystem-wide migration, consuming repositories must verify public capability contracts and architecture boundaries. No consumer should import private provider, storage, CLI or implementation modules.
 
-- Reconciled package metadata (`pyproject.toml`) and technical files (`api_service/app.py`, CLI commands, core configurations, and runtime) to point strictly to version `1.1.1`.
-- Documented system architecture boundaries and defined post-release maintenance policy in `MAINTENANCE.md`.
-- Configured automated dependency vulnerability audit gates in the CI pipeline.
+## Remaining engineering work
 
-## v1.0.0
+1. Ecosystem contract verification and boundary tests.
+2. Capability-contract conformance tests across Yasin-Agent, YasinHub, YasinCLI and domain integrations.
+3. Re-baselined roadmap for advanced routing, sandboxing and HA.
 
-- Reviewed and updated repository-wide documentation (`README.md`, `MASTER_PLAN.md`, `ARCHITECTURE.md`, `PROJECT_STATUS.md`, `CHANGELOG.md`) to ensure 100% perfect consistency with the current codebase, modules, CLI commands, parameters, and testing framework.
-- Deployment System implemented with Installer, Docker Manager, Health Check, and shared Package Builder (Issue #6).
-- Added comprehensive unit tests for Installer, DockerManager, HealthCheck, and PackageBuilder in `tests/test_deployment.py`.
-- Created Dockerfile and docker-compose.yml configurations at the repository root.
-- Created `requirements.txt` at the repository root.
-- Knowledge Platform fully implemented (Memory System, Knowledge Graph, Semantic Search, Context Engine, and Reasoning) (Issue #4).
-- Added comprehensive unit tests for MemoryManager, KnowledgeGraph, SemanticSearch, ContextBuilder, and KnowledgeReasoner.
-- Integrated CLI memory search with the actual retriever in the Knowledge Platform.
-- Core Runtime fully implemented (config, system info, service registry, dynamic bootstrap loading, lifecycle orchestration) (Issue #1).
-- Added comprehensive unit tests for Core Runtime config loading, service registry, bootstrap discovery, and state transition flow.
-- Initial production architecture completed.
-- Documentation prepared.
-- Release workflow prepared.
-
----
-
-End of Project Status
-
----
-
-## Phase 2 Progress (Updated 2026-08-14)
-
-| Task | Status |
-|---|---|
-| 2.1 Documentation & Source-of-Truth Reconciliation | COMPLETED — merged |
-| 2.2 Architecture Reconciliation | COMPLETED — merged |
-| 2.3 Version & Release Consistency | COMPLETED — PR #60 merged 2026-08-14 |
-| 2.4 AI Capability Catalog | COMPLETED — AI_CAPABILITY_CATALOG.md 2026-08-14 |
-| 2.5 AI Capability Contracts v1 | COMPLETED — yasinai/contracts/ v1, 34 tests, 2026-08-14 |
-| 2.6 Provider Architecture Audit | COMPLETED — yasinai/providers/ boundary, 23 tests, 2026-08-14 |
-| 2.7 Memory & Knowledge Architecture Reconciliation | COMPLETED — docs/MEMORY_KNOWLEDGE_ARCHITECTURE.md, yasinai/services/KnowledgeService, 14 tests |
-| 2.8 Foundation Tests, CI & Integration Readiness | COMPLETED — coverage 94%+, CI fail-under=85, sdk+entrypoint tests, observability in cov |
-| 15 Security audit closure (#51) | COMPLETED — re-verified 2026-08-14, residual risks documented |
-| 3.1 Concrete Provider Adapters (#68) | COMPLETED — OpenAI, Anthropic, Local + factory + tests |
-| 3.2 Generation Service Facade (#69) | COMPLETED — GenerationRequest/Result contracts + GenerationService |
-| 3.3 RAG Pipeline Orchestrator (#70) | COMPLETED — RagService + RagRequest/Result contracts |
-| 4.1 Yasin-Agent integration (#74) | COMPLETED — YasinAgentClient + INTEGRATION_YASIN_AGENT.md |
-| 4.2 YasinHub integration (#75) | COMPLETED — YasinHubClient + metrics snapshot + docs |
-| 4.3 YasinCLI integration (#76) | COMPLETED — YasinCLIClient + memory search via services |
-| 4.4 Relay/Feed/Press integration (#77) | COMPLETED — clients + docs for Relay, Feed, Press |
-| 5.1 Production deploy profile verification (#82) | COMPLETED — static gates for Dockerfile/compose |
-| 5.2 Plugin trust boundary policy (#83) | COMPLETED — trusted-only PluginRegistry + policy doc |
-| 5.3 Production readiness gate (#84) | COMPLETED — readiness tests + checklist sections 12–14 |
+Older Phase 2.x planning documents are historical unless explicitly listed as remaining work here.

--- a/README.md
+++ b/README.md
@@ -2,220 +2,148 @@
 
 Canonical AI Platform of the Yasin Ecosystem.
 
-According to YASIN-DOCS ADR-001, Yasin-AI is the Canonical AI Capability Platform for the Yasin ecosystem. It provides shared AI capabilities—such as model/provider abstraction, provider routing, inference services, embeddings, semantic retrieval, knowledge/RAG, durable AI memory contracts, AI extension contracts, and AI observability—while maintaining clear architectural boundaries with:
-- **Yasin-Core**: Generic runtime and SDK foundation.
-- **Yasin-Agent**: Agent planning, workflow, and execution semantics. (Although Yasin-AI includes local in-process Agent execution contracts, ecosystem-level Agent planning resides in Yasin-Agent).
-- **YasinHub**: Ecosystem control, lifecycle, and observability.
-- **YasinCLI**: Unified user-facing command surface. (The CLI in `yasinai/cli/` is a local diagnostic helper; the unified command interface is owned by YasinCLI).
-- **YasinRelay / YasinFeed / YasinPress**: Domain, content, and business pipelines.
+Yasin-AI v1.1.4 provides shared AI capabilities while maintaining explicit boundaries with Yasin-Core, Yasin-Agent, YasinHub, YasinCLI and the Relay/Feed/Press domain platforms.
 
-**Current release: v1.1.4**
-
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+**Current code line: v1.1.4**
 
 ## Status
 
-Yasin-AI has completed its Phase 2.2 architecture reconciliation.
+**Stable foundation / READY FOR CONTROLLED INTEGRATION.**
 
-- Reconciled version: **v1.1.4**
-- Security audit: completed
-- Release candidate verification: completed
-- Performance/reliability baseline: completed
-- Production deployment baseline: completed
-- Post-release maintenance policy: established
+The current line includes runtime, provider abstraction and concrete adapters, bounded retry/fallback, generation and RAG service boundaries, persistent local memory/knowledge, security, observability, packaging, CI and production container hardening.
 
-## Target Architecture
+This is not a distributed HA platform and does not sandbox untrusted plugins.
 
-The project is structured around clear boundaries and a strict downward dependency flow:
-
-```text
-API / SDK Contracts
-   │
-   ▼
-AI Runtime
-   │
-   ▼
-AI Services
-   │
-   ▼
-Provider / Knowledge / Memory Abstractions
-   │
-   ▼
-Concrete Implementations (e.g., SQLite DB, specific LLM API clients)
-```
-
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the complete canonical reference, subsystem responsibilities, and preferred dependency directions.
-
-## Core capabilities
+## Current capabilities
 
 ### Runtime
+- Modular lifecycle/bootstrap/configuration
+- Service registration and controlled shutdown
 
-- Modular runtime lifecycle
-- CLI-oriented operation
-- Explicit configuration and lifecycle management
-- Dependency-light core components
+### Providers and AI services
+- Provider abstraction
+- OpenAI, Anthropic and Local adapters
+- Provider factory
+- Bounded retry/fallback
+- Explicit provider/model selection with model-constraint preservation
+- GenerationService and public request/result contracts
+- RagService and public RAG contracts
 
-### Memory and Knowledge
+### Knowledge and Memory
+- Semantic search and retrieval
+- Knowledge graph/reasoning
+- SQLite-backed vector and memory persistence
+- WAL/busy-timeout concurrency hardening
 
-- Persistent local memory
-- SQLite-backed storage
-- Semantic/knowledge-oriented components
-- Replaceable persistence boundaries
-
-### Developer Platform
-
-- Extension/plugin interfaces
-- Narrow contracts for integrations
-- Developer-facing service boundaries
-
-### API and Services
-
-- Transport-neutral service layer
-- API-oriented request/response boundaries
-- Centralized error handling
-
-### Observability
-
-- Dependency-free counters and timers
-- Runtime instrumentation primitives
-- Performance/reliability regression coverage
+**Contract distinction:** Knowledge is information/content about the world or corpus. Memory is state associated with an interaction, entity or agent.
 
 ### Security
+- Authentication and authorization
+- Encryption/key handling
+- Repository security scanner
+- Input/path safety limits
+- Provider credential environment isolation
+- Internal error redaction
+- Trusted in-process plugin boundary
+- Canonical scanner-backed `security check`
 
-- Security policy and audit documentation
-- Dependency security auditing
-- Hardened production container baseline
-- Non-root container execution
-- Reduced Linux capabilities
-- no-new-privileges
-- Read-only root filesystem where supported
+### Deployment and quality
+- Production Docker hardening
+- Non-root execution, reduced capabilities and read-only production profile where supported
+- Python 3.9–3.12 CI matrix
+- Ruff
+- pip-audit
+- Security gate
+- Docker build/smoke validation
 
-See [SECURITY.md](SECURITY.md) and [SECURITY_AUDIT_2026-08-09.md](SECURITY_AUDIT_2026-08-09.md).
+## Provider routing: implemented vs planned
+
+**Implemented:** provider abstraction, provider selection, concrete adapters, bounded retry/fallback, explicit provider pinning and model-constraint preservation.
+
+**Planned:** cost-aware routing, health-aware load balancing, policy-aware orchestration and automatic multi-node failover.
+
+## Architecture boundaries
+
+```text
+Public API / SDK Contracts
+          │
+          ▼
+      AI Runtime
+          │
+          ▼
+      AI Services
+          │
+          ▼
+Provider / Knowledge / Memory abstractions
+          │
+          ▼
+Concrete storage/provider implementations
+```
+
+Consumers must not depend on private implementation modules, SQLite internals, provider-specific clients or local CLI internals.
 
 ## Installation
 
-Clone the repository:
-
-    git clone https://github.com/yusi20006-max/Yasin-AI.git
-    cd Yasin-AI
-
-Install the project using the repository's supported Python packaging configuration.
+```bash
+git clone https://github.com/yusi20006-max/Yasin-AI.git
+cd Yasin-AI
+python -m pip install -e .
+```
 
 ## Verification
 
-Before deploying a release, run:
+```bash
+python -m pytest -q
+pip-audit
+python -m build
+```
 
-    python -m pytest -q
-    pip-audit
-    python -m build
+Canonical security verification:
 
-Container deployments should additionally verify the production compose profile and healthcheck in the target environment.
+```bash
+yasin security check
+python -m yasinai.cli security check
+```
 
-## Release history
-
-- **v1.1.4** — Current production release (P1/P2 audit fixes + CI hardening) (includes Docker hardening + persistent storage + Python contract fixes)
-- **v1.1.1** — Phases 2–5 complete (contracts, providers, services, ecosystem integration)
-- **v1.1.0** — Maintenance baseline (aligned in Phase 2.2)
-- **v1.0.0** — First production release
-
-See the complete [release history](https://github.com/yusi20006-max/Yasin-AI/releases).
-
-## Security
-
-Security issues should be reported according to the project's security policy rather than through public issue disclosure.
-
-See [SECURITY.md](SECURITY.md).
-
-Important current security boundary:
-
-> Plugin execution is trusted and in-process. Untrusted remote plugin execution is not currently supported and requires a future sandbox/authorization layer.
+Both paths use the same canonical `SecurityScanner` semantics.
 
 ## Persistence and availability
 
-The default persistence model is local SQLite-backed storage.
-
-Yasin-AI does not currently claim:
+The default persistence model is local SQLite. Yasin-AI does not currently claim:
 
 - Distributed/high-availability storage
 - Automatic multi-node failover
 - Sandboxed execution of untrusted plugins
 
-These limitations are intentional and documented rather than hidden.
+These are explicit product boundaries, not hidden failures.
 
-## Production deployment
+## Ecosystem integration
 
-Production deployment guidance and hardening are documented in the repository deployment configuration and release documentation.
+v1.1.4 is suitable for controlled integration. Before broad migration, consuming repositories must verify public capability contracts and architecture boundaries. The integration target is Yasin-AI's public contracts, not its private implementation tree.
 
-The release candidate and production baseline are documented in:
+## Planned
 
-- [RELEASE_CANDIDATE.md](RELEASE_CANDIDATE.md)
-- [PRODUCTION_RELEASE.md](PRODUCTION_RELEASE.md)
-- [MAINTENANCE.md](MAINTENANCE.md)
+- Untrusted plugin sandboxing
+- Advanced provider routing and load balancing
+- Distributed/HA persistence
+- Advanced inference guardrails
+- Ecosystem observability adapters
+- Unified command-center integration through YasinCLI
 
-## Development
+## Release history
 
-Create a feature branch before making changes:
+- **v1.1.4** — Current code line; security/correctness/CI hardening
+- **v1.1.3** — Provider, RAG, Docker, plugin, input, SQLite and CI hardening
+- **v1.1.2** — Packaging, persistence and version-contract fixes
+- **v1.1.1** — Capability contracts, providers/services and ecosystem integration clients
+- **v1.1.0** — Architecture/documentation maintenance baseline
+- **v1.0.0** — Initial production baseline
 
-    git checkout -b feat/my-change
+See `CHANGELOG.md`, `VERSIONING_POLICY.md`, `docs/ARCHITECTURE.md` and `AI_CAPABILITY_CATALOG.md` for canonical detail.
 
-Run the verification suite:
+## Security
 
-    python -m pytest -q
-    pip-audit
-    python -m build
-
-Then submit changes through a pull request.
-
-## Capability Categorization & Project Boundaries
-
-To maintain strict source-of-truth accuracy, all Yasin-AI capabilities are organized into clear lifecycle categories:
-
-### IMPLEMENTED
-- **Modular Runtime & Lifecycle**: In-process module bootstrapping and runtime lifecycle manager (in `yasinai/core/`).
-- **Local SQLite Persistence**: SQLite-backed semantic vector storage for memory retrieval (in `knowledge_platform/`).
-- **In-process Plugin Extension**: SDK contracts enabling hot-toggling and execution of trusted, local plugins (in `developer_platform/`).
-- **Local CLI Commands**: Diagnostics, local status verification, and semantic search CLI helpers (in `yasinai/cli/`).
-- **API Service Layer**: Transport-neutral service interface and model schemas (in `api_service/`).
-- **Metrics Observability**: Cross-cutting instrumentation timer and counter primitives (in `observability/`).
-
-### CURRENT ARCHITECTURE
-- Single-process focus with clear internal component layering.
-- Configurable data directories and SQLite database paths.
-- Trusted plugin model (assumes running plugin code is safe).
-
-### PLANNED
-- **Remote Plugin Sandboxing**: Isolated, secure container/sandbox execution of untrusted third-party code.
-- **Multi-provider Routing**: Intelligent provider-routing, automatic LLM load-balancing, and fallback across cloud model vendors.
-- **Inference Guardrails**: Dynamic safety, cost-control, and latency-budget policies applied prior to inference.
-
-### FUTURE ECOSYSTEM CONTRACT
-- **Ecosystem Observability**: Exposing platform metrics and latency records directly to `YasinHub`.
-- **Ecosystem Agent Orchestration**: Delegating multi-step planning and runtime workflows to `Yasin-Agent`.
-- **Unified Command Center**: Porting and integrating local diagnostic commands (`status`, `memory`, etc.) directly into `YasinCLI`.
-
----
-
-## Known Platform Limitations & Truths
-
-- **No HA/Distribution**: The default local SQLite storage is a single-node database. It is not designed for multi-node clusters or high availability.
-- **In-process Trust**: The execution environment does not sandbox third-party plugin code. Only run trusted plugins.
-- **Resolved Version Contradiction**: In Phase 2.2, version inconsistencies across code metadata, CLI outputs, and documentation were unified to **v1.1.0** in Phase 2.2 and remain synchronized through **v1.1.2**.
-
----
-
-## Versioning
-
-Yasin-AI follows semantic versioning for releases.
-
-See the complete [Versioning Policy & Compatibility Model](VERSIONING_POLICY.md) for details on:
-- Where the authoritative package version resides
-- Runtime version programmatic retrieval
-- DEC and Contract version mapping
-- Release tagging procedures
-- Release state classification (released, development, planned)
-- Platform compatibility guarantees (Python versions, SQLite schemas, and vendor routing)
-
-Existing release tags are immutable. A new release receives a new version tag rather than moving an existing tag.
+Report security issues according to `SECURITY.md`. Never commit credentials or secrets.
 
 ## License
 

--- a/VERSIONING_POLICY.md
+++ b/VERSIONING_POLICY.md
@@ -1,94 +1,58 @@
 # Yasin-AI Versioning Policy and Compatibility Model
 
-This document defines the canonical versioning policy, release lifecycle, and compatibility model for Yasin-AI.
-
----
+This document is the canonical versioning policy for Yasin-AI.
 
 ## 1. Versioning Policy
 
-Yasin-AI strictly follows [Semantic Versioning 2.0.0 (SemVer)](https://semver.org/) for its package versions.
+Yasin-AI follows Semantic Versioning (SemVer).
 
-### 1.1. Authoritative Package Version
-- **Source of Truth**: The single authoritative source of truth for the platform version is defined in the `pyproject.toml` file under the `[project]` table:
-  ```toml
-  [project]
-  version = "1.1.0"
-  ```
-- **Runtime Version Retrieval**: The runtime/module version is obtained programmatically by importing the package's `__version__` attribute:
-  ```python
-  import yasinai
-  print(yasinai.__version__)  # Output: 1.1.0
-  ```
-  Alternatively, for installed packages, the standard library metadata can be used:
-  ```python
-  import importlib.metadata
-  print(importlib.metadata.version("yasinai"))  # Output: 1.1.0
-  ```
+### 1.1 Authoritative package version
+The authoritative package version is the `[project] version` in `pyproject.toml`.
 
-### 1.2. API & Capability Contract Versioning
-- **Separation of Concerns**: The Yasin-AI package version and the **AI Capability Contract version** are decoupled and must remain independently versionable.
-- **Contract Versioning**: The AI Capability Contract version (e.g., `v1`) represents the public request/response structures, stable endpoints, and in-process SDK integration points.
-- **Mapping/Compatibility Rule**:
-  - **Yasin-AI package (1.x.y)** implements **AI Capability Contract (v1)**.
-  - A major version increment of the package does not automatically force a major increment of the AI Capability Contract unless breaking API wire contracts are introduced.
+**Current stable version: `1.1.4`.**
 
-### 1.3. Release Tagging and Immutable Tags
-- **Tag Format**: Releases are tagged using a standard Git tag prefixed with `v` (e.g., `v1.1.0`).
-- **Tag Immutability**: Existing release tags are strictly **immutable**. Under no circumstances should an existing release tag be deleted or moved to a different commit. If a release contains a regression, a new patch release (e.g., `v1.1.1`) or hotfix must be cut.
-- **Release Commits**: Tags must point at the exact commit on `main` that passed all CI quality, security, and test gates.
+Runtime consumers should use `yasinai.__version__` or `importlib.metadata.version("yasinai")` rather than duplicating a version constant in documentation.
 
-### 1.4. Unreleased & Pre-Release Representation
-- **Unreleased / Development Changes**:
-  - During active development on a release line, the development version is suffixed with `-dev` or `.dev0` (e.g., `1.1.1-dev` or `1.2.0-dev`).
-  - This signifies that the code represents unreleased changes post the last stable release.
-- **Pre-Releases / Release Candidates**:
-  - Formal release previews are represented using standard SemVer suffixes:
-    - Alpha: `1.2.0-alpha.1`
-    - Beta: `1.2.0-beta.1`
-    - Release Candidate: `1.2.0-rc.1` (or `1.2.0-rc1`)
+### 1.2 API and capability contracts
+The package version and public AI capability contract versions are independently versioned. A package patch/minor release does not imply a contract-major change. Breaking public contracts require an explicitly versioned compatibility transition.
 
-### 1.5. CHANGELOG Structure
-- **Standard Format**: The project's `CHANGELOG.md` adheres to the [Keep a Changelog](https://keepachangelog.com/) format.
-- **Subheadings**: Every release section must categorize changes under:
-  - `Added` for new features.
-  - `Changed` for changes in existing functionality.
-  - `Deprecated` for soon-to-be-removed features.
-  - `Removed` for now-removed features.
-  - `Fixed` for any bug fixes.
-  - `Security` in case of vulnerabilities or security hardening.
-- **Timestamps**: Release titles must include the version and release date in `YYYY-MM-DD` format (e.g., `## [1.1.0] - 2026-08-12`).
+### 1.3 Release tags
+Release tags use the `vX.Y.Z` format and are immutable. A tag must point to the exact release commit that passed required CI, security and deployment gates. If a released tag is incorrect, do not move it; publish a new corrective release.
 
----
+### 1.4 Development and pre-release versions
+Unreleased development builds use a development/pre-release identifier such as `1.2.0.dev0` or `1.2.0-rc.1`. Documentation must never describe an unreleased development line as the current stable release.
+
+### 1.5 Changelog
+`CHANGELOG.md` follows Keep a Changelog. Each release records applicable Added, Changed, Deprecated, Removed, Fixed and Security changes with a release date.
 
 ## 2. Compatibility Model
 
-### 2.1. Python & Runtime Requirements
-- **Prerequisite**: Yasin-AI is declared and guaranteed compatible with Python version **`>=3.8`**.
-- **Installation Verifiers**: The environment installer verifies compatibility based on `sys.version_info` mapping major/minor requirements.
+### 2.1 Python
+The v1.1.4 CI matrix verifies Python 3.9, 3.10, 3.11 and 3.12. The package metadata remains authoritative for installation constraints.
 
-### 2.2. Package and SDK Compatibility
-- **Backward Compatibility**: Patch (`1.1.x`) and minor (`1.x.0`) package releases must maintain absolute backward compatibility with existing developer plugin extensions and Agent SDK clients.
-- **Breaking Changes**: Breaking package or API contract changes are restricted to new major version releases (e.g., `2.0.0`).
+### 2.2 Package and SDK compatibility
+Patch releases should preserve existing public behavior. Minor releases may add backward-compatible functionality. Breaking public API changes require a major release or an explicitly documented migration.
 
-### 2.3. Provider Routing & Compatibility
-- **Gateway Abstraction**: LLM providers and semantic/embedding drivers are accessed through transport-neutral wrappers.
-- **No Heavy Coupling**: System capabilities do not tightly couple with specific third-party provider versions. Vendor-specific routing is managed via configurable parameter interfaces rather than hardcoded client dependencies.
+### 2.3 Provider compatibility
+Yasin-AI currently provides provider abstraction, concrete provider adapters, bounded retry/fallback behavior, explicit provider/model selection and preservation of explicit model constraints. It does **not** claim cost-aware routing, health-aware load balancing or automatic multi-node provider orchestration.
 
-### 2.4. Persistence & Schema Compatibility
-- **Local SQLite Store**: Persistent memory and semantic retrieval rely on local SQLite files.
-- **Schema Migrations**:
-  - Minor and patch version upgrades must not break or invalidate existing SQLite databases or table schemas.
-  - If a schema evolution is required, a backward-compatible migration plan or migration helper must be provided to migrate data from the old table format to the new structure without data loss.
+### 2.4 Persistence
+The default persistence model is local SQLite. WAL and busy-timeout settings improve concurrent local access, but this is not a distributed/HA datastore. Schema changes must include a backward-compatible migration strategy where required.
 
----
+## 3. Release State Registry
 
-## 3. Platform Release State Registry
+| Version | State | Classification | Notes |
+|---|---|---|---|
+| `1.1.4` | Current code line | Stable | Current implementation baseline and audit/hardening line on `main`. |
+| `1.1.3` | Historical | Patch release | Provider, RAG, Docker, plugin, input-limit, SQLite and CI hardening. |
+| `1.1.2` | Historical | Patch release | Packaging, persistence, Docker and version-contract fixes. |
+| `1.1.1` | Historical | Feature release | Capability contracts, providers/services, ecosystem clients and production gates. |
+| `1.1.0` | Historical | Maintenance release | Architecture/documentation baseline. |
+| `1.0.0` | Historical | Major release | Initial production baseline. |
+| `1.2.x` | Planned | Future | Advanced routing, sandboxing and other capabilities only when implemented and verified. |
 
-This registry tracks the status and classification of known versions of Yasin-AI:
+## 4. Release Truth Rule
 
-| Version | Release Date | State | Classification | Description |
-|---|---|---|---|---|
-| **`1.1.0`** | 2026-08-12 | **Released** | Maintenance Release | Current stable production baseline. Features automated dependency audit and unified architecture docs. |
-| **`1.0.0`** | 2026-08-09 | **Released** | Major Release | Historical baseline launch. Hardened core runtime, persistent memory, and security platforms. |
-| **`1.1.1-dev`** | — | **Development** | Unreleased / Active | Active development stage focusing on Phase 2.3+ features and version alignment. |
-| **`1.2.0`** | Planned | **Planned** | Minor Release | Planned target featuring remote plugin sandboxing, provider gateways, and model registries. |
+Every release-related document must distinguish **implemented/current**, **historical**, **development**, and **planned** capabilities. Older roadmap phases are historical planning artifacts unless they still describe actual remaining work.
+
+Existing release tags are immutable. A corrective release must receive a new tag rather than rewriting an existing tag.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,119 +1,117 @@
 # Yasin-AI Canonical Architecture Reference
 
-Version: 1.1.0
-Status: Reconciled
+**Version:** 1.1.4  
+**Status:** Current / source-synchronized  
+**Last reconciled:** 2026-08-16
 
 ## 1. Overview
 
-Yasin-AI is structured as the Canonical AI Platform of the Yasin ecosystem. It is organized around clear layers to keep core runtime execution independent of specific transport endpoints, storage backends, telemetry exporters, and third-party AI models.
+Yasin-AI is the canonical AI capability platform of the Yasin ecosystem. v1.1.4 is a production baseline for controlled integration: it provides runtime, AI services, provider abstraction/adapters, bounded retry/fallback, knowledge/RAG services, persistent memory, security, observability, packaging and deployment foundations.
 
-### Target Canonical Layered Architecture
+It is **not** currently a distributed HA platform and does **not** sandbox untrusted plugin code.
+
+### Current layered architecture
 ```text
-                    Clients / Operators
-                           │
-             ┌─────────────▼─────────────┐
-             │     API / SDK Contracts   │  (External integration contracts)
-             └─────────────┬─────────────┘
-                           ▼
-             ┌───────────────────────────┐
-             │         AI Runtime        │  (Request orchestration & lifecycle)
-             └─────────────┬─────────────┘
-                           ▼
-             ┌───────────────────────────┐
-             │        AI Services        │  (Text generation, structured output)
-             └─────────────┬─────────────┘
-                           ▼
-             ┌───────────────────────────┐
-             │     Provider Gateway      │  (Model registry, routing, fallback)
-             └─────┬─────────────┬───────┘
-                   ▼             ▼
-             ┌───────────┐ ┌───────────┐
-             │ Knowledge │ │  Memory   │  (Semantic store vs episodic memory)
-             └───────────┘ └───────────┘
+Clients / Ecosystem Integrations
+              │
+              ▼
+       API / SDK Contracts
+              │
+              ▼
+          AI Runtime
+              │
+              ▼
+         AI Services
+              │
+              ▼
+   Provider / Knowledge / Memory
+        Abstractions
+          │       │
+          ▼       ▼
+     Providers   SQLite stores
 ```
 
----
+## 2. Ecosystem ownership boundaries
 
-## 2. Ecosystem Roles & Ownership Boundaries (YASIN-DOCS ADR-001)
+- **Yasin-Core:** generic runtime and SDK foundations.
+- **Yasin-Agent:** multi-step agent planning, reasoning loops and workflow semantics.
+- **YasinHub:** ecosystem control, lifecycle and cross-cutting observability.
+- **YasinCLI:** unified user-facing command surface; the local CLI in this repository remains a diagnostic/platform helper.
+- **YasinRelay / YasinFeed / YasinPress:** domain and business pipelines.
 
-Yasin-AI provides shared, reusable AI capabilities for all other platforms in the Yasin ecosystem. It adheres to strict ownership boundaries:
+External consumers must use stable public contracts rather than private implementation modules.
 
-- **Yasin-Core**: Standard runtime environment and general SDK foundations. Yasin-AI integrates with Yasin-Core during bootstrap, but does not duplicate general execution features.
-- **Yasin-Agent**: Governs multi-step agent planning, reasoning-loop orchestration, and workflow semantics.
-  *Boundary Note*: While Yasin-AI contains a local in-process `developer_platform/agent.py` to expose capability hook endpoints for libraries, all complex multi-step orchestrators belong strictly to **Yasin-Agent**.
-- **YasinHub**: Governs global ecosystem control, runtime lifecycles, and cross-cutting telemetry.
-  *Boundary Note*: Telemetry structures in `observability/` are local instrumentations. They will expose hooks to integrate directly with **YasinHub** in future phases.
-- **YasinCLI**: Represents the unified, user-facing control CLI.
-  *Boundary Note*: The local command runner `yasinai/cli/` is purely for local platform diagnostics; end-user commands will be ported into **YasinCLI**.
+## 3. Current capabilities
 
----
+### Runtime
+- lifecycle/bootstrap/configuration
+- service registration and controlled shutdown
 
-## 3. Preferred Dependency Direction
+### Provider layer
+- provider abstraction and concrete OpenAI/Anthropic/Local adapters
+- provider factory
+- bounded retry/fallback
+- explicit provider/model pinning and model-constraint preservation
 
-To maintain stability and enforce system boundaries, components must strictly adhere to the downward dependency direction:
+**Not implemented:** cost-aware routing, health-aware load balancing and automatic multi-node failover.
+
+### Knowledge and memory
+- semantic retrieval and TF-IDF baseline
+- SQLite-backed vector/knowledge persistence
+- knowledge graph and reasoning primitives
+- memory manager and durable local persistence
+- RAG service/orchestration boundary
+
+**Contract rule:** Knowledge means information about content/world state; Memory means interaction/entity/agent-associated state.
+
+### Security
+- authentication/authorization
+- encryption/key handling
+- repository security scanner
+- provider credential isolation via environment configuration
+- input/path limits and internal-error redaction
+- trusted-plugin boundary
+
+### Observability
+- counters/timers and local metrics snapshots
+
+## 4. Dependency direction
 
 ```text
-API / SDK Contracts
-   │
-   ▼
-AI Runtime
-   │
-   ▼
-AI Services
-   │
-   ▼
-Provider / Knowledge / Memory Abstractions
-   │
-   ▼
-Concrete Implementations (e.g., SQLite DB, specific LLM API clients)
+Public API / SDK Contracts
+          │
+          ▼
+      AI Runtime
+          │
+          ▼
+      AI Services
+          │
+          ▼
+Provider / Knowledge / Memory abstractions
+          │
+          ▼
+Concrete storage and provider implementations
 ```
 
-### Prohibited Patterns
-* **No Direct Implementation Leaks**: Applications or external agents must never import low-level driver or SQLite-specific logic directly. They must interact only with stable public contracts.
-* **No Circular Imports**: Runtime engines must never depend on the CLI or specific adapters.
+Prohibited: circular imports, CLI dependencies from runtime engines, and external consumers importing low-level storage/provider implementation details.
 
----
+## 5. Current repository structure
 
-## 4. Current Subsystem Breakdown & Reconciled Boundaries
+The repository still contains capability packages such as `api_service/`, `developer_platform/`, `security_platform/`, `knowledge_platform/`, `observability/`, and the main `yasinai/` package. A namespace rewrite is **not** a v1.1.4 prerequisite; existing boundaries are treated as stable until a compatibility-preserving migration is designed.
 
-Currently, the platform's codebase is divided into several local capability packages:
+## 6. Planned architecture
 
-### A. Core Runtime (`yasinai/core/`)
-Manages startup, settings, and graceful system shutdowns.
-* **`runtime.py`**: Manages runtime state transitions.
-* **`bootstrap.py`**: Discovers and instantiates platform modules.
-* **`config.py`**: Coordinates platform settings and defaults.
+The following are future work, not claims about v1.1.4:
 
-### B. API Service (`api_service/`)
-Implements transport-neutral request-dispatch interfaces to prevent core modules from coupling with web or IPC frameworks.
+1. **Advanced provider routing:** cost-aware, health-aware and policy-aware routing/load balancing.
+2. **Untrusted plugin sandboxing:** isolated execution with explicit authorization and resource limits.
+3. **Distributed/HA persistence:** remote/distributed storage and multi-node failover.
+4. **Ecosystem observability contracts:** direct YasinHub integration.
+5. **Advanced agent orchestration:** owned by Yasin-Agent.
+6. **Unified command center:** owned by YasinCLI.
 
-### C. Developer Platform (`developer_platform/`)
-Exposes integration surfaces and extension SDKs:
-* **`agent.py` & `app.py`**: Local in-process wrapper APIs.
-* **`plugin.py` & `extension.py`**: Hot-toggling and local execution of trusted user plugins.
-* **`debugger.py` & `profiler.py`**: Performance analysis tools.
+Old Phase 2.3/2.4/2.5 roadmap labels are historical planning artifacts and must not be interpreted as evidence that the corresponding work is still unimplemented.
 
-### D. Knowledge Platform (`knowledge_platform/`)
-* **`semantic_search.py`**: Implements dependency-free TF-IDF vector math and retriever pipelines (`Retriever`, `EmbeddingEngine`).
-* **`memory.py` & `memory_store.py`**: SQLite-backed conversational persistence and episodic managers.
-* **`graph.py` & `triple_store.py`**: Constructs relational networks.
-* **`reasoning.py`**: Simple logical deduction rules.
+## 7. Production boundary
 
-### E. Security Platform (`security_platform/`)
-Hardens local platform identity, permissions, custom AES/HMAC encryption, and audit events.
-
-### F. Observability (`observability/`)
-Contains internal timer and counter telemetry.
-
----
-
-## 5. Planned & Future Architecture Corrections (Deferred Refactoring)
-
-As a result of the Phase 2.2 reconciliation, structural re-organizations are deferred to subsequent phases to maintain safe, incremental progress:
-
-1. **Namespace Consolidation (Phase 2.3)**:
-   * Move standalone directories (`api_service/`, `developer_platform/`, `security_platform/`, `observability/`) inside the main `yasinai/` package to resolve public/private boundary ambiguities.
-2. **Provider Gateway Construction (Phase 2.4)**:
-   * Introduce a centralized Provider Gateway layer containing a model registry, retry/fallback handling, and active provider health checks.
-3. **Module Splitting (Phase 2.5)**:
-   * Separate `knowledge_platform/` into distinct `knowledge/` (ingestion, RAG, triple store) and `memory/` (durable session histories, memory policies) packages.
+v1.1.4 is **ready for controlled ecosystem integration**, subject to contract verification by each consuming repository. It must not be described as a complete distributed ecosystem AI platform.


### PR DESCRIPTION
Synchronize stale release/version/architecture/capability documentation with the actual v1.1.4 implementation.

Changes:
- update VERSIONING_POLICY to v1.1.4 and historical release registry
- rebaseline architecture document and remove stale Phase 2.3–2.5 implementation claims
- replace stale AI capability catalog with source-verified v1.1.4 capability classification
- synchronize PROJECT_STATUS with current implementation and remaining integration work
- remove README contradictions around version, provider routing, and planned capabilities

No runtime behavior is changed.