### PR TITLE
feat(contracts): freeze Public API Contract v1 (#130)

### DIFF
--- a/docs/PUBLIC_API_CONTRACT.md
+++ b/docs/PUBLIC_API_CONTRACT.md
@@ -1,0 +1,128 @@
+# Yasin-AI Public API Contract
+
+**Contract version:** v1  
+**Platform version:** 1.1.4  
+**Status:** Frozen for ecosystem consumers (Agent, Core, CLI, Hub, Relay, Feed, Press)
+
+This document is the **canonical public surface** of Yasin-AI. Consumers **must** import only symbols and packages listed here. Anything not listed is **private** and may change without notice.
+
+---
+
+## 1. Supported import paths
+
+| Package / module | Public? | Purpose |
+|---|---|---|
+| `yasinai` | Yes | Package version (`__version__`) |
+| `yasinai.contracts` | Yes | Capability request/response contracts |
+| `yasinai.services` | Yes | Service facades (generation, knowledge, RAG) |
+| `yasinai.providers` | Yes | Provider abstraction, registry, router, concrete adapters |
+| `yasinai.providers.base` | Yes | `ProviderBase`, request/response DTOs, errors |
+| `yasinai.integration` | Yes | Reference ecosystem clients |
+| `yasinai.core.runtime` | Yes | `Runtime` lifecycle |
+| `yasinai.core.config` | Yes | `Config` |
+| `yasinai.cli` | Yes | Local diagnostic CLI entry (`yasin`) |
+| `api_service` | Yes | Transport-neutral API service |
+| `observability` | Yes | Metrics primitives (`Counter`, `Timer`, `MetricsRegistry`) |
+
+### Explicitly private (do **not** import from consumers)
+
+| Module / package | Reason |
+|---|---|
+| `knowledge_platform` | Internal knowledge/memory implementation |
+| `developer_platform` | Internal developer/plugin implementation |
+| `security_platform` | Internal security implementation (use CLI/`yasin security check`) |
+| `yasinai.providers.openai_provider` internals beyond public class export | Prefer `yasinai.providers` |
+| Any `_`-prefixed symbol | Private by convention |
+
+---
+
+## 2. Version
+
+```python
+import yasinai
+assert yasinai.__version__  # e.g. "1.1.4"
+```
+
+**Compatibility policy:** Semantic Versioning. Within `1.1.x`, public contracts (`CONTRACT_VERSION = "v1"`) remain backward-compatible. Breaking public API changes require a major package version and a new contract version.
+
+---
+
+## 3. Capability contracts (`yasinai.contracts`)
+
+`CONTRACT_VERSION = "v1"`
+
+### Base
+- `CapabilityMetadata`, `ObservabilityContext`
+- `CapabilityError`, `CapabilityUnavailableError`, `ContractViolationError`
+
+### Memory
+- `MemoryType`, `MemoryRequest`, `MemoryResponse`, `MemoryEntry`
+
+### Knowledge
+- `KnowledgeQueryType`, `KnowledgeQuery`, `KnowledgeEntry`, `KnowledgeResult`
+
+### Generation
+- `GenerationRequest`, `GenerationResult`
+
+### RAG
+- `RagRequest`, `RagResult`
+
+### Embedding
+- `EmbeddingRequest`, `EmbeddingResponse`, `EmbeddingVector`
+
+### Plugin
+- `PluginContract`, `PluginInvokeRequest`, `PluginInvokeResponse`
+
+---
+
+## 4. Services (`yasinai.services`)
+
+- `KnowledgeService` — memory + knowledge facade
+- `GenerationService` — text generation via providers
+- `RagService` — retrieval-augmented generation
+
+---
+
+## 5. Providers (`yasinai.providers`)
+
+- `ProviderBase`, `ProviderCapability`, `ProviderInfo`
+- `ProviderError`, `ProviderRegistry`, `ProviderRouter`, `ProviderUnavailableError`
+- `GenerationRequest`, `GenerationResponse` (provider-layer DTOs)
+- `OpenAIProvider`, `AnthropicProvider`, `LocalProvider`
+- `build_default_registry`
+
+**Implemented:** explicit provider/model selection, bounded retry/fallback, env-only credentials.  
+**Not implemented:** cost-aware / health-aware / load-balanced routing (planned).
+
+---
+
+## 6. Runtime & configuration
+
+- `yasinai.core.runtime.Runtime` — lifecycle (`start` / `shutdown`, states)
+- `yasinai.core.config.Config` — defaults + `YASINAI_*` env overrides
+
+---
+
+## 7. Integration clients (`yasinai.integration`)
+
+Reference clients (not required, but supported):
+
+`YasinAgentClient`, `YasinHubClient`, `YasinCLIClient`, `YasinRelayClient`, `YasinFeedClient`, `YasinPressClient`
+
+---
+
+## 8. Error contract (summary)
+
+- Contract validation → `ContractViolationError` (or service result with `success=False`)
+- Provider unavailable / model mismatch → `ProviderUnavailableError` / `GenerationResult.success=False`
+- Unexpected internals **must not** appear in `GenerationResult.error` / `RagResult.error` / API bodies
+
+Detailed API error schemas: see issue #147 and `api_service` responses.
+
+---
+
+## 9. Verification
+
+Automated: `tests/test_public_api_contract.py` (must pass in CI).
+
+Every symbol listed in the machine-readable registry in that test **must** import successfully.

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -1,0 +1,124 @@
+"""#130 — automated verification of the frozen Public API Contract."""
+from __future__ import annotations
+
+import importlib
+import ast
+from pathlib import Path
+
+import pytest
+
+# Machine-readable public symbol registry (must match docs/PUBLIC_API_CONTRACT.md)
+PUBLIC_IMPORTS: dict[str, list[str]] = {
+    "yasinai": ["__version__"],
+    "yasinai.contracts": [
+        "CONTRACT_VERSION",
+        "CapabilityError",
+        "CapabilityMetadata",
+        "CapabilityUnavailableError",
+        "ContractViolationError",
+        "ObservabilityContext",
+        "MemoryType",
+        "MemoryRequest",
+        "MemoryResponse",
+        "MemoryEntry",
+        "KnowledgeQueryType",
+        "KnowledgeQuery",
+        "KnowledgeEntry",
+        "KnowledgeResult",
+        "GenerationRequest",
+        "GenerationResult",
+        "RagRequest",
+        "RagResult",
+        "EmbeddingRequest",
+        "EmbeddingResponse",
+        "EmbeddingVector",
+        "PluginContract",
+        "PluginInvokeRequest",
+        "PluginInvokeResponse",
+    ],
+    "yasinai.services": [
+        "KnowledgeService",
+        "GenerationService",
+        "RagService",
+    ],
+    "yasinai.providers": [
+        "ProviderBase",
+        "ProviderCapability",
+        "ProviderInfo",
+        "ProviderError",
+        "ProviderRegistry",
+        "ProviderRouter",
+        "ProviderUnavailableError",
+        "GenerationRequest",
+        "GenerationResponse",
+        "OpenAIProvider",
+        "AnthropicProvider",
+        "LocalProvider",
+        "build_default_registry",
+    ],
+    "yasinai.integration": [
+        "YasinAgentClient",
+        "YasinHubClient",
+        "YasinCLIClient",
+        "YasinRelayClient",
+        "YasinFeedClient",
+        "YasinPressClient",
+    ],
+    "yasinai.core.runtime": ["Runtime"],
+    "yasinai.core.config": ["Config"],
+    "observability": ["Counter", "Timer", "MetricsRegistry"],
+    "api_service": [],  # package importable
+}
+
+PRIVATE_PACKAGES = (
+    "knowledge_platform",
+    "developer_platform",
+    "security_platform",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("module_name,symbols", list(PUBLIC_IMPORTS.items()))
+def test_public_module_importable(module_name: str, symbols: list[str]):
+    mod = importlib.import_module(module_name)
+    for name in symbols:
+        assert hasattr(mod, name), f"{module_name}.{name} missing from public surface"
+
+
+def test_contract_version_is_v1():
+    from yasinai.contracts import CONTRACT_VERSION
+
+    assert CONTRACT_VERSION == "v1"
+
+
+def test_platform_version_present():
+    import yasinai
+
+    assert isinstance(yasinai.__version__, str) and yasinai.__version__
+
+
+def test_public_api_contract_doc_exists():
+    path = ROOT / "docs" / "PUBLIC_API_CONTRACT.md"
+    assert path.is_file()
+    text = path.read_text(encoding="utf-8")
+    assert "Public API Contract" in text
+    assert "knowledge_platform" in text  # marked private
+    assert "CONTRACT_VERSION" in text or "v1" in text
+
+
+def test_integration_clients_do_not_import_private_packages():
+    integ = ROOT / "yasinai" / "integration"
+    for path in integ.glob("*.py"):
+        if path.name.startswith("_"):
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported.add(alias.name.split(".")[0])
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".")[0])
+        for forbidden in PRIVATE_PACKAGES:
+            assert forbidden not in imported, f"{path.name} imports {forbidden}"

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -1,8 +1,8 @@
 """#130 — automated verification of the frozen Public API Contract."""
 from __future__ import annotations
 
-import importlib
 import ast
+import importlib
 from pathlib import Path
 
 import pytest

--- a/yasinai/providers/__init__.py
+++ b/yasinai/providers/__init__.py
@@ -28,7 +28,7 @@ from yasinai.providers.factory import build_default_registry, register_default_p
 from yasinai.providers.local_provider import LocalProvider
 from yasinai.providers.openai_provider import OpenAIProvider
 from yasinai.providers.registry import ProviderRegistry
-from yasinai.providers.router import ProviderRouter
+from yasinai.providers.router import ProviderRouter, ProviderUnavailableError
 
 __all__ = [
     "AnthropicProvider",
@@ -42,6 +42,7 @@ __all__ = [
     "ProviderInfo",
     "ProviderRegistry",
     "ProviderRouter",
+    "ProviderUnavailableError",
     "build_default_registry",
     "register_default_providers",
 ]


### PR DESCRIPTION
## Closes #130

- Canonical `docs/PUBLIC_API_CONTRACT.md`
- Automated symbol verification in CI
- ProviderUnavailableError exported
- 314 tests passed