### PR TITLE
docs+test: ecosystem version compatibility matrix (#135)

### DIFF
--- a/docs/ECOSYSTEM_COMPATIBILITY_MATRIX.md
+++ b/docs/ECOSYSTEM_COMPATIBILITY_MATRIX.md
@@ -1,0 +1,29 @@
+# Yasin Ecosystem Version Compatibility Matrix
+
+**Yasin-AI platform version:** 1.1.4  
+**Public API contract:** v1  
+**Last updated:** 2026-08-16
+
+## Policy
+
+- Yasin-AI follows SemVer. Within `1.1.x`, public contracts (`CONTRACT_VERSION = "v1"`) remain backward-compatible.
+- Ecosystem consumers must depend on **public** packages only (`yasinai.contracts`, `yasinai.services`, `yasinai.providers`, `yasinai.integration`, `yasinai.core.runtime` / `config`).
+- Private packages (`knowledge_platform`, `developer_platform`, `security_platform`) are **not** part of the compatibility surface.
+
+## Supported ranges (Yasin-AI 1.1.4)
+
+| Consumer | Minimum Yasin-AI | Maximum Yasin-AI (inclusive) | Contract | Notes |
+|---|---|---|---|---|
+| Yasin-Agent | `>=1.1.4` | `<1.2.0` | v1 | Use `yasinai.integration.YasinAgentClient` or contracts/services directly |
+| Yasin-Core | `>=1.1.4` | `<1.2.0` | v1 | Runtime + Config public API |
+| Yasin-CLI | `>=1.1.4` | `<1.2.0` | v1 | Local `yasin` CLI + `YasinCLIClient` |
+
+## Machine-readable matrix
+
+See `yasinai/compatibility.py` — imported by `tests/test_compatibility_matrix.py` and usable by CI.
+
+## Verification
+
+```bash
+python -m pytest tests/test_compatibility_matrix.py -q
+```

--- a/tests/test_compatibility_matrix.py
+++ b/tests/test_compatibility_matrix.py
@@ -1,0 +1,39 @@
+"""#135 — machine-checkable ecosystem version compatibility matrix."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yasinai
+from yasinai.compatibility import COMPATIBILITY_MATRIX, is_compatible
+from yasinai.contracts import CONTRACT_VERSION
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_matrix_covers_required_consumers():
+    names = {r["consumer"] for r in COMPATIBILITY_MATRIX}
+    assert names >= {"yasin-agent", "yasin-core", "yasin-cli"}
+
+
+def test_current_platform_is_compatible_with_all_consumers():
+    for row in COMPATIBILITY_MATRIX:
+        assert is_compatible(row["consumer"], yasinai.__version__)
+
+
+def test_incompatible_versions_rejected():
+    assert is_compatible("yasin-agent", "1.0.0") is False
+    assert is_compatible("yasin-agent", "2.0.0") is False
+    assert is_compatible("unknown-product", yasinai.__version__) is False
+
+
+def test_contract_version_aligned():
+    assert CONTRACT_VERSION == "v1"
+    assert all(r["contract"] == "v1" for r in COMPATIBILITY_MATRIX)
+
+
+def test_matrix_document_exists():
+    path = ROOT / "docs" / "ECOSYSTEM_COMPATIBILITY_MATRIX.md"
+    assert path.is_file()
+    text = path.read_text(encoding="utf-8")
+    assert "Yasin-Agent" in text
+    assert "1.1.4" in text

--- a/yasinai/compatibility.py
+++ b/yasinai/compatibility.py
@@ -1,0 +1,49 @@
+"""Ecosystem version compatibility matrix (#135)."""
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class CompatEntry(TypedDict):
+    consumer: str
+    min_yasinai: str
+    max_yasinai_exclusive: str
+    contract: str
+
+
+# Canonical matrix for platform 1.1.4 / contract v1
+COMPATIBILITY_MATRIX: list[CompatEntry] = [
+    {
+        "consumer": "yasin-agent",
+        "min_yasinai": "1.1.4",
+        "max_yasinai_exclusive": "1.2.0",
+        "contract": "v1",
+    },
+    {
+        "consumer": "yasin-core",
+        "min_yasinai": "1.1.4",
+        "max_yasinai_exclusive": "1.2.0",
+        "contract": "v1",
+    },
+    {
+        "consumer": "yasin-cli",
+        "min_yasinai": "1.1.4",
+        "max_yasinai_exclusive": "1.2.0",
+        "contract": "v1",
+    },
+]
+
+
+def _parse(v: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in v.split(".")[:3])
+
+
+def is_compatible(consumer: str, yasinai_version: str) -> bool:
+    """Return True if *yasinai_version* satisfies the matrix row for *consumer*."""
+    key = consumer.lower().replace("_", "-")
+    for row in COMPATIBILITY_MATRIX:
+        if row["consumer"] != key:
+            continue
+        ver = _parse(yasinai_version)
+        return _parse(row["min_yasinai"]) <= ver < _parse(row["max_yasinai_exclusive"])
+    return False


### PR DESCRIPTION
## Closes #135

Canonical matrix + machine-checkable `yasinai.compatibility`.