### PR TITLE
docs: sync MASTER_PLAN.md and AGENTS.md to actual v1.1.4 state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Name:
 YasinAI
 
 Version:
-1.1.1
+1.1.4
 
 
 ## Role
@@ -181,7 +181,7 @@ Do not perform large refactors without approval.
 
 Current target:
 
-YasinAI v1.1.1
+YasinAI v1.1.4 — see `PROJECT_STATUS.md` for the authoritative current-state summary before starting any release work.
 
 
 Before release:

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -6,7 +6,7 @@ Name:
 YasinAI (Canonical AI Platform)
 
 Version Target:
-v1.1.0
+v1.1.4
 
 Type:
 Canonical AI Capability Platform of the Yasin Ecosystem (YASIN-DOCS ADR-001)
@@ -234,15 +234,16 @@ yasinai/deployment/
 We classify milestones to distinguish clearly between current stable baselines and active development lines:
 
 ### CURRENT BASELINE
-- **v1.1.0 (Maintenance Release)**: Consolidates codebase versioning and adds automated dependency security auditing to CI.
+- **v1.1.4 (Audit/Correctness/Security Hardening)**: Provider abstraction with concrete adapters, bounded retry/fallback, generation and RAG service boundaries, local persistent memory/knowledge with concurrency hardening, security controls, observability, packaging, CI (Ruff, pip-audit, security gate, Docker smoke) and production container baseline.
+- **v1.1.0 – v1.1.3**: Historical maintenance releases — see `PROJECT_STATUS.md` release table and `CHANGELOG.md` for details.
 - **v1.0.0 (Production Release)**: Baseline production launch featuring memory pipelines, developer platforms, and core runtimes.
 
 ### ACTIVE DEVELOPMENT
-- **Phase 2.3 (Version & Release Consistency)**: Align version sources of truth, establish standard versioning policies, and compatibility mappings.
+- **Ecosystem Contract Verification**: Verify capability-contract conformance across Yasin-Agent, YasinHub, YasinCLI, YasinRelay, YasinFeed and YasinPress, and confirm no consumer imports private Yasin-AI implementation modules.
 
 ### PLANNED FUTURE VERSIONS
-- **v1.2.0 (Minor Release)**: Provider Gateway routing, model registry, inference guardrails, and isolated plugin sandboxing.
-- **v2.0.0 (Major Release)**: Distributed AI Network, agent collaboration networks, and YasinHub telemetry endpoints.
+- **v1.2.0 (Minor Release)**: Cost-aware and health-aware provider routing, automatic multi-node provider failover, model registry, inference guardrails, and isolated plugin sandboxing.
+- **v2.0.0 (Major Release)**: Distributed/HA persistence, agent collaboration networks, and YasinHub telemetry endpoints.
 
 ---
 
@@ -276,12 +277,14 @@ Never commit:
 
 # Current Mission
 
-Establish strict versioning and release source of truth.
+Verify ecosystem-wide capability contracts and architecture boundaries before controlled integration migration.
 
 Tasks:
-1. Reconcile version references across all docs to point to `1.1.0` (Active).
-2. Authorize standard versioning policy document (`VERSIONING_POLICY.md`) (Active).
-3. Ensure no version drift across package metadata and runtime (Active).
+1. Ecosystem contract verification and boundary tests across Yasin-Agent, YasinHub, YasinCLI, YasinRelay, YasinFeed and YasinPress (Active).
+2. Capability-contract conformance tests confirming no consumer imports private provider, storage, CLI or implementation modules (Active).
+3. Re-baseline the roadmap for advanced provider routing, plugin sandboxing and distributed/HA persistence (Planned — see `PROJECT_STATUS.md`).
+
+See `PROJECT_STATUS.md` for the authoritative current-state summary and `VERSIONING_POLICY.md` for version governance.
 
 ---
 


### PR DESCRIPTION
Fixes #174.

## Changes
Independent audit found `MASTER_PLAN.md` and `AGENTS.md` still presented old versions as current, despite `pyproject.toml` being `1.1.4` and `PROJECT_STATUS.md` already correctly reporting `v1.1.4`.

- `MASTER_PLAN.md`: version target, "CURRENT BASELINE", "ACTIVE DEVELOPMENT", and "Current Mission" sections all updated to reflect v1.1.4 and the real remaining work per `PROJECT_STATUS.md` (ecosystem contract verification across Yasin-Agent/YasinHub/YasinCLI/etc., re-baselined roadmap for advanced routing/sandboxing/HA).
- `AGENTS.md`: `Version:` field and "Current target" in Release Rules updated to v1.1.4, with a pointer to `PROJECT_STATUS.md` as the authoritative current-state doc.

`AGENTS.md` was the more important fix: it's the file coding agents are instructed to read first, so a stale version there risked a future agent believing the project was still on v1.1.1.

## Constraints respected
- Historical version mentions (e.g. "v1.1.0 was a maintenance release") kept as-is — only references presenting an old version as *current* were changed.
- `PROJECT_STATUS.md`, `VERSIONING_POLICY.md`, `CHANGELOG.md` untouched (already correct).
- No structural rewrite — targeted fixes to the stale sections only.

## Verification
Full suite: 398 passed. `ruff check .` clean. Grepped both files post-fix to confirm no remaining v1.1.0/v1.1.1-as-current references.
