### PR TITLE
phase 4: finalize ecosystem integration policy and Python 3.13 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout repository

--- a/docs/INTEGRATION_YASIN_FEED.md
+++ b/docs/INTEGRATION_YASIN_FEED.md
@@ -3,6 +3,12 @@
 **Phase:** 4.4  
 **Date:** 2026-08-14
 
+> **Integration policy:** `YasinFeedClient` below is a supported reference
+> wrapper, not a requirement. YasinFeed's shipped Yasin-AI provider integrates
+> directly through the canonical public `yasinai.contracts` and
+> `yasinai.services` surfaces. Both approaches remain supported; consumers do
+> not need to migrate solely because of this policy.
+
 YasinFeed owns feed/timeline aggregation. Use `YasinFeedClient` for
 semantic ranking and card summaries.
 

--- a/docs/INTEGRATION_YASIN_PRESS.md
+++ b/docs/INTEGRATION_YASIN_PRESS.md
@@ -3,6 +3,12 @@
 **Phase:** 4.4  
 **Date:** 2026-08-14
 
+> **Integration policy:** `YasinPressClient` below is a supported reference
+> wrapper, not a requirement. YasinPress's shipped integration uses the
+> canonical public `yasinai.contracts` and `yasinai.services` surfaces directly.
+> Both approaches remain supported; consumers do not need to migrate solely
+> because of this policy.
+
 YasinPress owns publishing/editorial workflows. Use `YasinPressClient`
 for drafts and grounded research.
 

--- a/docs/INTEGRATION_YASIN_RELAY.md
+++ b/docs/INTEGRATION_YASIN_RELAY.md
@@ -3,6 +3,12 @@
 **Phase:** 4.4  
 **Date:** 2026-08-14
 
+> **Integration policy:** `YasinRelayClient` below is a supported reference
+> wrapper, not a requirement. YasinRelay's shipped adapter integrates directly
+> through the canonical public `yasinai.contracts` and `yasinai.services`
+> surfaces. Both approaches remain supported; consumers do not need to migrate
+> solely because of this policy.
+
 YasinRelay owns message/event relay. Use `YasinRelayClient` for payload
 enrichment and grounded answers — contracts/services only.
 

--- a/yasinai/integration/__init__.py
+++ b/yasinai/integration/__init__.py
@@ -1,9 +1,18 @@
 """
-Ecosystem integration reference clients (Phase 4).
+Ecosystem integration reference clients.
 
-These modules show how external Yasin products should consume Yasin-AI
-**only** through public contracts and service facades — never through
-`knowledge_platform`, `developer_platform`, or provider SDKs.
+Policy (decided Phase 4, documented Phase 5): these classes are public,
+tested, supported **reference/convenience wrappers** around
+`yasinai.contracts` / `yasinai.services` — they are NOT the mandatory or
+exclusive consumer integration path. Consuming `yasinai.contracts` and
+`yasinai.services` directly is equally supported and is, in practice, the
+path every current real integration (YasinRelay, YasinFeed, YasinPress)
+uses. Use whichever fits your consumer's existing patterns.
+
+What both paths share, and must continue to share: external Yasin
+products consume Yasin-AI **only** through public contracts and service
+facades — never through `knowledge_platform`, `developer_platform`, or
+provider SDKs directly.
 """
 
 from yasinai.integration.agent_client import YasinAgentClient


### PR DESCRIPTION
## Summary
- document Policy C for ecosystem integration clients as supported reference/convenience wrappers rather than a mandatory path
- clarify Relay/Feed/Press integration docs around the canonical `yasinai.contracts` / `yasinai.services` surface
- add Python 3.13 to the existing CI test matrix

## Validation
- Existing Phase 4 baseline on the parent commit: 398 tests passed under Python 3.12.3.
- The new Python 3.13 result must be taken from GitHub Actions on this PR; no local Python 3.13 result is claimed.

## Constraints
- No public API renames
- No architecture change
- Integration clients remain public and backward compatible
- No secrets or external API keys required