### PR TITLE
fix(deployment): make PackageBuilder cwd-independent

### DIFF
--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -144,6 +144,26 @@ def test_package_builder_build(tmp_path):
     assert res_other["package_name"] == "custom-plugin-v2.5.tar.gz"
 
 
+def test_package_builder_build_from_unrelated_cwd(tmp_path, monkeypatch):
+    builder = PackageBuilder()
+    output = tmp_path / "dist"
+    unrelated_cwd = tmp_path / "unrelated"
+    unrelated_cwd.mkdir()
+    monkeypatch.chdir(unrelated_cwd)
+
+    result = builder.build_package(name="yasinai", version="1.0.0", output_directory=str(output))
+
+    assert result["success"] is True
+    assert "yasinai/core/" in result["files_included"]
+    assert "yasinai/cli/" in result["files_included"]
+    assert "pyproject.toml" in result["files_included"]
+    with tarfile.open(result["archive_path"], "r:gz") as archive:
+        members = archive.getnames()
+    assert members
+    assert all(not member.startswith("/") for member in members)
+    assert all(".." not in member.split("/") for member in members)
+
+
 def test_package_builder_archive_member_names_are_safe(tmp_path):
     builder = PackageBuilder()
     source = tmp_path / "src"

--- a/yasinai/deployment/package_builder.py
+++ b/yasinai/deployment/package_builder.py
@@ -17,6 +17,7 @@ _DEFAULT_INCLUDE_PATHS = (
     "yasinai/cli/",
     "pyproject.toml",
 )
+_PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 
 
 class PackageBuilder:
@@ -33,7 +34,12 @@ class PackageBuilder:
         """
         Bundle the given paths into a real .tar.gz deployment artifact.
 
-        Source paths may be relative or absolute for backwards compatibility.
+        When ``include_paths`` is omitted, the builder resolves its default
+        source paths relative to the Yasin-AI package/repository root rather
+        than the caller's current working directory. Explicit paths remain
+        relative to the caller's cwd (for backwards compatibility) or may be
+        absolute.
+
         Archive member names are always normalized to relative paths derived
         from a common source root, preventing absolute/``..`` traversal names
         from being emitted into the resulting tarball.
@@ -44,14 +50,27 @@ class PackageBuilder:
             version,
             output_directory,
         )
-        paths_to_include = list(include_paths) if include_paths is not None else list(_DEFAULT_INCLUDE_PATHS)
+        using_defaults = include_paths is None
+        paths_to_include = list(_DEFAULT_INCLUDE_PATHS if using_defaults else include_paths)
 
         try:
             package_name = f"{name}-pkg-{version}.tar.gz" if "yasinai" in name else f"{name}-v{version}.tar.gz"
             os.makedirs(output_directory, exist_ok=True)
             archive_path = os.path.join(output_directory, package_name)
 
-            resolved_paths = [(path, Path(path).resolve()) for path in paths_to_include if os.path.exists(path)]
+            def resolve_source(path: str) -> Path:
+                candidate = Path(path)
+                if candidate.is_absolute():
+                    return candidate.resolve()
+                base = _PACKAGE_ROOT if using_defaults else Path.cwd()
+                return (base / candidate).resolve()
+
+            resolved_paths = [
+                (path, resolved)
+                for path in paths_to_include
+                for resolved in [resolve_source(path)]
+                if resolved.exists()
+            ]
             common_root = (
                 Path(os.path.commonpath([str(resolved.parent) for _, resolved in resolved_paths]))
                 if resolved_paths
@@ -71,7 +90,7 @@ class PackageBuilder:
                     files_included.append(original_path)
 
                 for path in paths_to_include:
-                    if not os.path.exists(path):
+                    if not resolve_source(path).exists():
                         logger.warning("Skipping missing path for package '%s': '%s'", name, path)
 
             result = {


### PR DESCRIPTION
## Phase 5 — P2 robustness fix

Fixes #177.

### Changes
- Resolve PackageBuilder default include paths from the Yasin-AI repository/package root instead of the caller's current working directory.
- Preserve explicit absolute paths.
- Preserve existing caller-cwd semantics for explicitly supplied relative paths.
- Add regression coverage that changes cwd to an unrelated directory before invoking the default package build.
- Keep archive member normalization/traversal checks intact.

### Validation
GitHub Actions should run the full supported Python matrix and coverage gate.

This is a focused Phase 5 fix; no public API rename or architecture change.