### PR TITLE
phase 5: harden deployment path resolution and external-cwd CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,32 @@ jobs:
           path: coverage.xml
           if-no-files-found: ignore
 
+  cwd-robustness:
+    name: Deployment tooling from external cwd
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package and test dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -e ".[test]"
+
+      - name: Run deployment tests outside repository cwd
+        run: |
+          set -euo pipefail
+          cd /tmp
+          python -m pytest "$GITHUB_WORKSPACE/tests/test_deployment.py" -q
+
   lint:
     name: Lint (Ruff)
     runs-on: ubuntu-latest

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -144,6 +144,14 @@ def test_package_builder_build(tmp_path):
     assert res_other["package_name"] == "custom-plugin-v2.5.tar.gz"
 
 
+def test_package_builder_default_paths_are_independent_of_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = PackageBuilder().build_package(name="yasinai", version="1.0.0")
+    assert result["success"] is True
+    assert "yasinai/core/" in result["files_included"]
+    assert (tmp_path / "dist" / "yasinai-pkg-1.0.0.tar.gz").exists()
+
+
 def test_package_builder_archive_member_names_are_safe(tmp_path):
     builder = PackageBuilder()
     source = tmp_path / "src"

--- a/yasinai/deployment/package_builder.py
+++ b/yasinai/deployment/package_builder.py
@@ -22,6 +22,29 @@ _DEFAULT_INCLUDE_PATHS = (
 class PackageBuilder:
     """Builds source-based deployment archives with safe archive member names."""
 
+    _PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+    @classmethod
+    def _resolve_source_path(cls, path: str) -> Path | None:
+        """Resolve a source path without making default project paths cwd-dependent.
+
+        Relative paths that exist under the Yasin-AI project root are resolved
+        there first. This keeps the default source set usable when callers run
+        the builder from outside the repository. Explicit paths that do not
+        exist under the project root retain the historical cwd-relative
+        behavior for backwards compatibility.
+        """
+        candidate = Path(path)
+        if candidate.is_absolute():
+            return candidate.resolve() if candidate.exists() else None
+
+        project_candidate = (cls._PROJECT_ROOT / candidate).resolve()
+        if project_candidate.exists():
+            return project_candidate
+
+        cwd_candidate = candidate.resolve()
+        return cwd_candidate if cwd_candidate.exists() else None
+
     def build_package(
         self,
         name: str,
@@ -34,9 +57,11 @@ class PackageBuilder:
         Bundle the given paths into a real .tar.gz deployment artifact.
 
         Source paths may be relative or absolute for backwards compatibility.
-        Archive member names are always normalized to relative paths derived
-        from a common source root, preventing absolute/``..`` traversal names
-        from being emitted into the resulting tarball.
+        Relative project paths are resolved from the package project root,
+        rather than the caller's current working directory. Archive member
+        names are always normalized to relative paths derived from a common
+        source root, preventing absolute/``..`` traversal names from being
+        emitted into the resulting tarball.
         """
         logger.info(
             "Building deployment package '%s' (version=%s) to directory '%s'...",
@@ -51,7 +76,11 @@ class PackageBuilder:
             os.makedirs(output_directory, exist_ok=True)
             archive_path = os.path.join(output_directory, package_name)
 
-            resolved_paths = [(path, Path(path).resolve()) for path in paths_to_include if os.path.exists(path)]
+            resolved_paths = [
+                (path, resolved)
+                for path in paths_to_include
+                if (resolved := self._resolve_source_path(path)) is not None
+            ]
             common_root = (
                 Path(os.path.commonpath([str(resolved.parent) for _, resolved in resolved_paths]))
                 if resolved_paths
@@ -71,7 +100,7 @@ class PackageBuilder:
                     files_included.append(original_path)
 
                 for path in paths_to_include:
-                    if not os.path.exists(path):
+                    if self._resolve_source_path(path) is None:
                         logger.warning("Skipping missing path for package '%s': '%s'", name, path)
 
             result = {


### PR DESCRIPTION
## Scope
Phase 5A/5B stabilization work.

### Phase 5A
- Make `PackageBuilder` resolve default project-relative source paths from the project root instead of the caller's current working directory.
- Preserve backwards-compatible resolution for explicit absolute paths and relative paths outside the project root.
- Add a regression test that invokes the default package build from an external working directory.

### Phase 5B
- Keep the existing direct Python 3.13 matrix validation.
- Add a Python 3.13 CI job that runs the deployment test suite from `/tmp` using the repository test path, guarding against cwd-sensitive regressions.

### Validation
The repository's existing full matrix remains the primary validation gate. The new external-cwd job is intentionally separate so the regression is visible as its own CI signal.

No architecture or public API changes are introduced.