### PR TITLE
Support current Termux Python 3.14 installation

### DIFF
--- a/docs/TERMUX.md
+++ b/docs/TERMUX.md
@@ -1,0 +1,39 @@
+# Yasin-AI on Termux
+
+Yasin-AI treats Termux on Android as a first-class deployment target.
+
+## Current Termux Python
+
+Current Termux releases may ship Python 3.14. Yasin-AI must not require an older Python merely because an Android wheel is unavailable or incompatible.
+
+The Termux bootstrap builds `cryptography` from source so its native extension is compiled against the exact Python/Android environment in use. This avoids the `PyLong_Type` dynamic-loader failure observed with the prebuilt Android wheel.
+
+## Installation
+
+From the repository root:
+
+```bash
+bash scripts/install_termux.sh
+```
+
+The bootstrap installs the required Termux toolchain, creates `.venv`, installs `cryptography` from source, verifies its native backend, installs Yasin-AI, and runs the test suite.
+
+## Required Termux packages
+
+- `python`
+- `clang`
+- `rust`
+- `make`
+- `pkg-config`
+- `openssl`
+- `openssl-tool`
+- `libffi`
+- `git`
+- `cmake`
+- `patchelf`
+
+`cargo` is provided by the Termux `rust` package and should not be installed as a separate package.
+
+## Known compatibility rule
+
+Do not force a prebuilt `cryptography` wheel on Termux. The bootstrap uses `PIP_NO_BINARY=cryptography` intentionally.

--- a/scripts/install_termux.sh
+++ b/scripts/install_termux.sh
@@ -1,0 +1,53 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+# Yasin-AI Termux bootstrap.
+# Termux currently ships Python 3.14; do not force an older Python.
+# cryptography's prebuilt Android wheel can be ABI-incompatible with the
+# Termux Python build, so build cryptography from source against this Python.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+pkg update -y
+pkg install -y \
+  python clang rust make pkg-config openssl openssl-tool libffi git cmake patchelf
+
+PYTHON_BIN="${PYTHON_BIN:-python}"
+"$PYTHON_BIN" - <<'PY'
+import sys
+if sys.version_info < (3, 14):
+    raise SystemExit(f"Yasin-AI Termux bootstrap expects current Termux Python >=3.14; found {sys.version.split()[0]}")
+print(f"Using Python {sys.version.split()[0]}")
+PY
+
+rm -rf .venv
+"$PYTHON_BIN" -m venv .venv
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+python -m pip install --upgrade pip setuptools wheel
+
+# Never consume the Termux-incompatible Android cryptography wheel.
+PIP_NO_BINARY=cryptography python -m pip install --no-cache-dir cffi cryptography
+
+python - <<'PY'
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+print("cryptography native backend: OK")
+print("AESGCM backend: OK")
+PY
+
+python -m pip install -e ".[dev]"
+python - <<'PY'
+import yasinai
+print(f"Yasin-AI {getattr(yasinai, '__version__', 'unknown')}: import OK")
+PY
+
+python -m pytest -q
+
+echo
+printf '%s\n' 'Yasin-AI Termux installation completed successfully.'
+printf '%s\n' 'Activate: source .venv/bin/activate'
+printf '%s\n' 'CLI: yasin --help'
+printf '%s\n' 'Runtime: yasin serve'

--- a/tests/test_termux_bootstrap.py
+++ b/tests/test_termux_bootstrap.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "install_termux.sh"
+DOC = ROOT / "docs" / "TERMUX.md"
+
+
+def test_termux_bootstrap_exists_and_is_fail_fast() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "set -euo pipefail" in text
+    assert "pkg install -y" in text
+    assert "python clang rust make pkg-config openssl openssl-tool" in text
+    assert "PIP_NO_BINARY=cryptography" in text
+    assert "cryptography.exceptions import InvalidTag" in text
+    assert "cryptography.hazmat.primitives.ciphers.aead import AESGCM" in text
+
+
+def test_termux_docs_match_bootstrap() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    assert "Python 3.14" in text
+    assert "PyLong_Type" in text
+    assert "scripts/install_termux.sh" in text
+    assert "PIP_NO_BINARY=cryptography" in text


### PR DESCRIPTION
## What changed
- Add a first-class Termux bootstrap for the current Python 3.14 environment.
- Install the complete Termux native build toolchain required by Yasin-AI and `cryptography`.
- Force `cryptography` to build from source on Termux instead of consuming the incompatible Android wheel that produced the `PyLong_Type` loader failure.
- Verify the native cryptography backend before installing/running Yasin-AI.
- Add Termux deployment documentation and regression tests for the bootstrap contract.

## Root cause
Termux currently provides Python 3.14.6 on the tested Android environment. The prebuilt `cryptography` Android wheel installed successfully but failed at import with `dlopen failed: cannot locate symbol "PyLong_Type"`. The project itself passed 374 tests when the cryptography-dependent tests were excluded, confirming the failure is environmental/native-wheel compatibility rather than the Yasin-AI application code.

## Validation
The Termux-specific native build must be validated on the target Termux device because GitHub Actions does not reproduce its Android/aarch64 environment. The new bootstrap performs that validation before continuing.
