### PR TITLE
Fix Termux installation with native cryptography

### DIFF
--- a/docs/TERMUX.md
+++ b/docs/TERMUX.md
@@ -4,9 +4,13 @@ Yasin-AI treats Termux on Android as a first-class deployment target.
 
 ## Current Termux Python
 
-Current Termux releases may ship Python 3.14. Yasin-AI must not require an older Python merely because an Android wheel is unavailable or incompatible.
+Current Termux releases ship the current Python line (3.14.x in the tested environment). Yasin-AI must not require an older Python merely because a PyPI Android wheel is unavailable or ABI-incompatible.
 
-The Termux bootstrap builds `cryptography` from source so its native extension is compiled against the exact Python/Android environment in use. This avoids the `PyLong_Type` dynamic-loader failure observed with the prebuilt Android wheel.
+## Cryptography
+
+Termux provides a native `python-cryptography` package. The Yasin-AI Termux bootstrap installs and uses that package inside a `--system-site-packages` virtual environment. This is intentional: the PyPI Android `cryptography` wheel and a source build both produced native-loader/toolchain failures in the tested Termux environment.
+
+The bootstrap verifies `cryptography` and `AESGCM` before installing Yasin-AI and prevents pip dependency resolution from replacing the Termux-native package.
 
 ## Installation
 
@@ -16,11 +20,12 @@ From the repository root:
 bash scripts/install_termux.sh
 ```
 
-The bootstrap installs the required Termux toolchain, creates `.venv`, installs `cryptography` from source, verifies its native backend, installs Yasin-AI, and runs the test suite.
+The bootstrap installs the required Termux packages, creates `.venv` with access to Termux-native packages, verifies cryptography, installs Yasin-AI and its test tools, and runs the full test suite.
 
 ## Required Termux packages
 
 - `python`
+- `python-cryptography`
 - `clang`
 - `rust`
 - `make`
@@ -36,4 +41,4 @@ The bootstrap installs the required Termux toolchain, creates `.venv`, installs 
 
 ## Known compatibility rule
 
-Do not force a prebuilt `cryptography` wheel on Termux. The bootstrap uses `PIP_NO_BINARY=cryptography` intentionally.
+Do not install or upgrade `cryptography` from PyPI in the Termux deployment environment. Use the Termux-native package selected by the bootstrap.

--- a/scripts/install_termux.sh
+++ b/scripts/install_termux.sh
@@ -2,16 +2,16 @@
 set -euo pipefail
 
 # Yasin-AI Termux bootstrap.
-# Termux currently ships Python 3.14; do not force an older Python.
-# cryptography's prebuilt Android wheel can be ABI-incompatible with the
-# Termux Python build, so build cryptography from source against this Python.
+# Termux is a first-class target and uses the current Termux Python.
+# Do not force an older Python just to satisfy PyPI Android wheels.
+# Termux packages cryptography natively; using that package avoids the
+# PyO3/ABI dynamic-loader failures seen with PyPI Android wheels.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 pkg update -y
-pkg install -y \
-  python clang rust make pkg-config openssl openssl-tool libffi git cmake patchelf
+pkg install -y python python-cryptography clang rust make pkg-config openssl openssl-tool libffi git cmake patchelf
 
 PYTHON_BIN="${PYTHON_BIN:-python}"
 "$PYTHON_BIN" - <<'PY'
@@ -22,28 +22,33 @@ print(f"Using Python {sys.version.split()[0]}")
 PY
 
 rm -rf .venv
-"$PYTHON_BIN" -m venv .venv
-# shellcheck disable=SC1091
+"$PYTHON_BIN" -m venv --system-site-packages .venv
 source .venv/bin/activate
-
 python -m pip install --upgrade pip setuptools wheel
 
-# Never consume the Termux-incompatible Android cryptography wheel.
-PIP_NO_BINARY=cryptography python -m pip install --no-cache-dir cffi cryptography
-
 python - <<'PY'
-from cryptography.exceptions import InvalidTag
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-print("cryptography native backend: OK")
+import importlib.metadata as metadata
+import sys
+try:
+    import cryptography
+    from cryptography.exceptions import InvalidTag
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+except Exception as exc:
+    print(f"Termux cryptography check failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+    raise SystemExit(20)
+print(f"Termux cryptography {metadata.version('cryptography')}: import OK")
 print("AESGCM backend: OK")
 PY
 
-python -m pip install -e ".[dev]"
+# Install Yasin without dependency resolution so pip cannot overwrite the
+# ABI-matched Termux cryptography package. Dev/test tools are pure Python.
+python -m pip install -e ".[dev]" --no-deps
+python -m pip install 'pytest>=7.4,<10' 'pytest-cov>=6,<8'
+
 python - <<'PY'
 import yasinai
 print(f"Yasin-AI {getattr(yasinai, '__version__', 'unknown')}: import OK")
 PY
-
 python -m pytest -q
 
 echo

--- a/tests/test_termux_bootstrap.py
+++ b/tests/test_termux_bootstrap.py
@@ -9,16 +9,17 @@ DOC = ROOT / "docs" / "TERMUX.md"
 def test_termux_bootstrap_exists_and_is_fail_fast() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
     assert "set -euo pipefail" in text
-    assert "pkg install -y" in text
-    assert "python clang rust make pkg-config openssl openssl-tool" in text
-    assert "PIP_NO_BINARY=cryptography" in text
+    assert "python-cryptography" in text
+    assert "--system-site-packages" in text
+    assert "pip install -e \".[dev]\" --no-deps" in text
     assert "cryptography.exceptions import InvalidTag" in text
     assert "cryptography.hazmat.primitives.ciphers.aead import AESGCM" in text
+    assert "PIP_NO_BINARY=cryptography" not in text
 
 
 def test_termux_docs_match_bootstrap() -> None:
     text = DOC.read_text(encoding="utf-8")
     assert "Python 3.14" in text
-    assert "PyLong_Type" in text
+    assert "python-cryptography" in text
+    assert "system-site-packages" in text
     assert "scripts/install_termux.sh" in text
-    assert "PIP_NO_BINARY=cryptography" in text


### PR DESCRIPTION
## Goal
Make the Yasin-AI Termux installer reliable on current Termux Python 3.14 without requiring an older Python.

## Root cause
The previous bootstrap forced `cryptography` from PyPI. In the tested Termux environment, both the prebuilt Android wheel and a source build failed at the native Rust/PyO3 layer (`PyLong_Type` loader failure / missing Android Rust target). Termux maintains a native `python-cryptography` package specifically to avoid this class of compilation/ABI problem. citeturn1search0turn1search1

## Fix
- Install `python-cryptography` through Termux `pkg`.
- Create the project venv with `--system-site-packages` so the ABI-matched native package is visible.
- Verify `cryptography` and `AESGCM` before installing Yasin-AI.
- Install Yasin-AI with `--no-deps` so pip cannot replace the native Termux cryptography package.
- Install pytest/pytest-cov explicitly as pure-Python development dependencies.
- Update Termux documentation and bootstrap regression tests.

## Validation
The target device must run `bash scripts/install_termux.sh` because GitHub Actions does not provide the same Android/Termux runtime.
