### PR TITLE
feat: add generic provider configuration and first-run API setup

### DIFF
--- a/docs/GENERIC_PROVIDER_SETUP.md
+++ b/docs/GENERIC_PROVIDER_SETUP.md
@@ -1,0 +1,49 @@
+# Generic Provider Setup
+
+Yasin-AI can connect to an OpenAI-compatible API without adding a provider-specific adapter.
+
+## First-time setup
+
+Set the Yasin-AI master key in the process environment. It protects the encrypted provider credentials and is never written by Yasin-AI:
+
+```bash
+export YASINAI_MASTER_KEY='choose-a-strong-secret'
+```
+
+Then configure a provider:
+
+```bash
+yasin provider setup
+```
+
+The CLI asks for:
+
+- provider name
+- Base URL
+- model
+- API key (hidden input)
+
+The API key is encrypted with the existing Yasin-AI AES-256-GCM security engine. Provider metadata is stored under `~/.config/yasinai/providers.json` (or the path in `YASINAI_PROVIDER_CONFIG`) with restrictive file permissions.
+
+Remote Base URLs must use HTTPS. `localhost`, `127.0.0.1`, and `::1` are allowed over HTTP for local development.
+
+## Multiple providers
+
+```bash
+yasin provider setup
+yasin provider list
+yasin provider use <name>
+yasin provider test <name>
+yasin provider remove <name>
+```
+
+The configured providers are loaded into the normal Yasin-AI provider registry at runtime. Consumers continue to use the existing public `GenerationService` and generation contracts.
+
+No provider-specific code is required for a compatible gateway. For example, a compatible Iranian gateway can be configured by entering its Base URL, API key, and model name.
+
+## Security notes
+
+- API keys are never printed by the CLI.
+- API keys are not stored as plaintext in the provider configuration file.
+- API keys are not included in provider listing output.
+- Real credentials must never be committed to the repository or used in CI tests.

--- a/tests/cli/test_provider_cli.py
+++ b/tests/cli/test_provider_cli.py
@@ -1,0 +1,10 @@
+from yasinai.cli.provider import create_parser
+
+
+def test_provider_cli_parser_supports_required_commands():
+    parser = create_parser()
+    assert parser.parse_args(["list"]).action == "list"
+    assert parser.parse_args(["setup"]).action == "setup"
+    assert parser.parse_args(["use", "gateway"]).name == "gateway"
+    assert parser.parse_args(["test", "gateway"]).name == "gateway"
+    assert parser.parse_args(["remove", "gateway"]).name == "gateway"

--- a/tests/providers/test_config_store.py
+++ b/tests/providers/test_config_store.py
@@ -1,0 +1,52 @@
+import json
+
+import pytest
+
+from yasinai.providers.config_store import ProviderConfigError, ProviderStore, validate_base_url
+
+
+def test_validate_base_url_requires_https_for_remote():
+    assert validate_base_url("https://example.com/v1/") == "https://example.com/v1"
+    assert validate_base_url("http://localhost:8000/v1/") == "http://localhost:8000/v1"
+    with pytest.raises(ProviderConfigError):
+        validate_base_url("http://example.com/v1")
+
+
+def test_store_persists_metadata_but_not_plaintext_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("YASINAI_MASTER_KEY", "test-master-key")
+    path = tmp_path / "providers.json"
+    store = ProviderStore(path)
+    store.save(
+        name="gateway",
+        base_url="https://example.com/v1",
+        model="model-x",
+        api_key="super-secret",
+        make_default=True,
+    )
+
+    raw = path.read_text(encoding="utf-8")
+    assert "super-secret" not in raw
+    payload = json.loads(raw)
+    assert payload["default"] == "gateway"
+    assert payload["providers"]["gateway"]["model"] == "model-x"
+    assert store.get("gateway")["api_key"] == "super-secret"
+    assert store.default()["name"] == "gateway"
+
+
+def test_store_supports_multiple_providers_and_default_switch(tmp_path, monkeypatch):
+    monkeypatch.setenv("YASINAI_MASTER_KEY", "test-master-key")
+    store = ProviderStore(tmp_path / "providers.json")
+    for name in ("one", "two"):
+        store.save(
+            name=name,
+            base_url="https://example.com/v1",
+            model="model",
+            api_key=name + "-secret",
+            make_default=name == "one",
+        )
+
+    assert {item["name"] for item in store.list()} == {"one", "two"}
+    store.use("two")
+    assert store.default()["name"] == "two"
+    assert store.remove("two") is True
+    assert store.default()["name"] == "one"

--- a/tests/providers/test_generic_openai.py
+++ b/tests/providers/test_generic_openai.py
@@ -1,0 +1,43 @@
+from yasinai.providers.base import GenerationRequest
+from yasinai.providers.generic_openai import GenericOpenAIProvider
+
+
+def test_generic_provider_uses_runtime_name_url_model_and_transport():
+    calls = {}
+
+    def transport(url, headers, body):
+        calls.update({"url": url, "headers": headers, "body": body})
+        return {
+            "id": "test-1",
+            "model": "custom-model",
+            "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+        }
+
+    provider = GenericOpenAIProvider(
+        name="my-gateway",
+        base_url="https://gateway.example/v1/",
+        api_key="secret-key",
+        default_model="custom-model",
+        transport=transport,
+    )
+    result = provider.generate(GenerationRequest(prompt="hello"))
+
+    assert result.text == "ok"
+    assert result.provider == "my-gateway"
+    assert result.model == "custom-model"
+    assert calls["url"] == "https://gateway.example/v1/chat/completions"
+    assert calls["headers"]["Authorization"] == "Bearer secret-key"
+    assert calls["body"]["model"] == "custom-model"
+
+
+def test_generic_provider_info_contains_runtime_identity():
+    provider = GenericOpenAIProvider(
+        name="gateway",
+        base_url="https://gateway.example/v1",
+        api_key="secret",
+        default_model="model-x",
+    )
+    assert provider.info.name == "gateway"
+    assert provider.info.model_ids == ["model-x"]
+    assert provider.info.metadata["protocol"] == "openai-chat-completions"

--- a/yasinai/cli/provider.py
+++ b/yasinai/cli/provider.py
@@ -1,0 +1,158 @@
+"""CLI for runtime-configured OpenAI-compatible providers."""
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import sys
+from typing import Any
+from urllib.parse import urlparse
+
+from yasinai.contracts import GenerationRequest as PublicGenerationRequest
+from yasinai.providers.config_store import ProviderConfigError, ProviderStore, validate_base_url
+from yasinai.providers.generic_openai import GenericOpenAIProvider
+
+
+def _build_provider(config: dict[str, str], transport: Any = None) -> GenericOpenAIProvider:
+    return GenericOpenAIProvider(
+        name=config["name"],
+        base_url=config["base_url"],
+        api_key=config["api_key"],
+        default_model=config["model"],
+        transport=transport,
+    )
+
+
+def _test_provider(config: dict[str, str]) -> None:
+    provider = _build_provider(config)
+    request = PublicGenerationRequest(prompt="Reply with exactly: YASIN_OK", model=config["model"], max_tokens=8, temperature=0.0)
+    provider.generate(request)
+
+
+def _prompt_setup(existing: dict[str, str] | None = None) -> dict[str, str]:
+    existing = existing or {}
+    name = input(f"Provider name [{existing.get('name', '')}]: ").strip() or existing.get("name", "")
+    base_url = input(f"Base URL [{existing.get('base_url', '')}]: ").strip() or existing.get("base_url", "")
+    model = input(f"Model [{existing.get('model', '')}]: ").strip() or existing.get("model", "")
+    key = getpass.getpass("API Key (hidden): ")
+    if not key and existing:
+        key = existing["api_key"]
+    return {"name": name, "base_url": base_url, "model": model, "api_key": key}
+
+
+def handle_setup(args: argparse.Namespace) -> int:
+    store = ProviderStore()
+    try:
+        current = store.get(args.name) if args.name else None
+        config = _prompt_setup(current)
+        validate_base_url(config["base_url"])
+        print("Testing provider connection...")
+        _test_provider(config)
+        store.save(**config, make_default=bool(args.default))
+        print(f"SUCCESS: provider '{config['name']}' configured and tested.")
+        return 0
+    except (ProviderConfigError, ValueError, OSError) as exc:
+        print(f"Provider setup failed: {exc}", file=sys.stderr)
+        return 1
+    except Exception:
+        print("Provider setup failed: connection test did not succeed.", file=sys.stderr)
+        return 1
+
+
+def handle_list(args: argparse.Namespace) -> int:
+    try:
+        rows = ProviderStore().list()
+        if args.json:
+            print(json.dumps(rows, indent=2))
+            return 0
+        if not rows:
+            print("No providers configured.")
+            return 0
+        for item in rows:
+            marker = "*" if item["default"] else " "
+            print(f"{marker} {item['name']}  {item['model']}  {item['base_url']}")
+        return 0
+    except ProviderConfigError as exc:
+        print(f"Provider list failed: {exc}", file=sys.stderr)
+        return 1
+
+
+def handle_use(args: argparse.Namespace) -> int:
+    try:
+        ProviderStore().use(args.name)
+        print(f"Default provider: {args.name}")
+        return 0
+    except ProviderConfigError as exc:
+        print(f"Provider selection failed: {exc}", file=sys.stderr)
+        return 1
+
+
+def handle_remove(args: argparse.Namespace) -> int:
+    try:
+        removed = ProviderStore().remove(args.name)
+        if not removed:
+            print(f"Provider '{args.name}' is not configured.", file=sys.stderr)
+            return 1
+        print(f"Removed provider '{args.name}'.")
+        return 0
+    except ProviderConfigError as exc:
+        print(f"Provider removal failed: {exc}", file=sys.stderr)
+        return 1
+
+
+def handle_test(args: argparse.Namespace) -> int:
+    try:
+        config = ProviderStore().get(args.name) if args.name else ProviderStore().default()
+        if not config:
+            print("No provider is configured.", file=sys.stderr)
+            return 1
+        print(f"Testing provider '{config['name']}'...")
+        _test_provider(config)
+        print("SUCCESS: provider connection and model test passed.")
+        return 0
+    except ProviderConfigError as exc:
+        print(f"Provider test failed: {exc}", file=sys.stderr)
+        return 1
+    except Exception:
+        print("Provider test failed: connection or model request was unsuccessful.", file=sys.stderr)
+        return 1
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="yasin provider", description="Manage runtime-configured AI providers")
+    sub = parser.add_subparsers(dest="action")
+
+    setup = sub.add_parser("setup", help="Add or update a provider")
+    setup.add_argument("name", nargs="?", help="Existing provider name to update")
+    setup.add_argument("--default", action="store_true", help="Make this provider the default")
+    setup.set_defaults(func=handle_setup)
+
+    listing = sub.add_parser("list", help="List configured providers")
+    listing.add_argument("--json", action="store_true")
+    listing.set_defaults(func=handle_list)
+
+    use = sub.add_parser("use", help="Select the default provider")
+    use.add_argument("name")
+    use.set_defaults(func=handle_use)
+
+    test = sub.add_parser("test", help="Test a configured provider")
+    test.add_argument("name", nargs="?")
+    test.set_defaults(func=handle_test)
+
+    remove = sub.add_parser("remove", help="Remove a configured provider")
+    remove.add_argument("name")
+    remove.set_defaults(func=handle_remove)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = create_parser()
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    if not getattr(args, "action", None):
+        parser.print_help()
+        return 0
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/yasinai/cli/security_entrypoint.py
+++ b/yasinai/cli/security_entrypoint.py
@@ -16,14 +16,7 @@ def _finding_id(finding: dict) -> str | None:
 
 
 def security_check(argv: list[str]) -> int:
-    """Run the canonical scanner with a stable CLI presentation.
-
-    All security decisions and values come from ``SecurityScanner``. The
-    ``checks`` compatibility field and legacy heading are presentation-only;
-    they never contain hard-coded pass/fail results. Scanner findings may be
-    represented by older/partial schemas, so presentation must not crash when
-    optional metadata such as ``id`` or ``path`` is absent.
-    """
+    """Run the canonical scanner with a stable CLI presentation."""
     from security_platform.scanner import SecurityScanner
 
     json_output = "--json" in argv
@@ -49,9 +42,6 @@ def security_check(argv: list[str]) -> int:
             print(f"{status} {name} [{severity}]{location}")
             print(f"         Details: {details}")
 
-        # Backward-compatible human-readable alias for the canonical secret
-        # scan. It is printed only from the actual scanner result. Older report
-        # schemas may omit the optional finding id, so lookup must be tolerant.
         secret_finding = next(
             (item for item in findings if _finding_id(item) == "SEC_SECRET_001"),
             None,
@@ -69,6 +59,9 @@ def main(argv: list[str] | None = None) -> None:
     args = list(sys.argv[1:] if argv is None else argv)
     if len(args) >= 2 and args[0] == "security" and args[1] == "check":
         raise SystemExit(security_check(args[2:]))
+    if args and args[0] == "provider":
+        from yasinai.cli.provider import main as provider_main
+        raise SystemExit(provider_main(args[1:]))
 
     cli = importlib.import_module("yasinai.cli.main")
     cli.main(args)

--- a/yasinai/providers/config_store.py
+++ b/yasinai/providers/config_store.py
@@ -1,7 +1,7 @@
 """Persistent configuration for runtime-defined providers.
 
 Provider metadata is stored as JSON, while API keys are encrypted with the
-existing Yasin-AI AES-256-GCM engine.  The encryption master key is accepted
+existing Yasin-AI AES-256-GCM engine. The encryption master key is accepted
 only from ``YASINAI_MASTER_KEY`` and is never written by this module.
 """
 from __future__ import annotations
@@ -17,6 +17,9 @@ from security_platform.encryption import EncryptionEngine
 
 class ProviderConfigError(ValueError):
     """Raised when provider configuration is invalid or unavailable."""
+
+
+RESERVED_PROVIDER_NAMES = {"local", "openai", "anthropic"}
 
 
 def validate_base_url(base_url: str) -> str:
@@ -103,6 +106,8 @@ class ProviderStore:
         model = model.strip()
         if not name:
             raise ProviderConfigError("Provider name must not be empty")
+        if name.lower() in RESERVED_PROVIDER_NAMES:
+            raise ProviderConfigError(f"Provider name '{name}' is reserved")
         if not model:
             raise ProviderConfigError("Model must not be empty")
         if not api_key:

--- a/yasinai/providers/config_store.py
+++ b/yasinai/providers/config_store.py
@@ -1,0 +1,141 @@
+"""Persistent configuration for runtime-defined providers.
+
+Provider metadata is stored as JSON, while API keys are encrypted with the
+existing Yasin-AI AES-256-GCM engine.  The encryption master key is accepted
+only from ``YASINAI_MASTER_KEY`` and is never written by this module.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from security_platform.encryption import EncryptionEngine
+
+
+class ProviderConfigError(ValueError):
+    """Raised when provider configuration is invalid or unavailable."""
+
+
+def validate_base_url(base_url: str) -> str:
+    """Validate and normalize a provider API base URL."""
+    value = base_url.strip().rstrip("/")
+    parsed = urlparse(value)
+    if parsed.scheme not in {"https", "http"} or not parsed.netloc:
+        raise ProviderConfigError("Base URL must be a valid HTTP(S) URL")
+    host = (parsed.hostname or "").lower()
+    local = host in {"localhost", "127.0.0.1", "::1"}
+    if parsed.scheme != "https" and not local:
+        raise ProviderConfigError("Remote provider Base URL must use HTTPS")
+    if parsed.username or parsed.password:
+        raise ProviderConfigError("Base URL must not contain embedded credentials")
+    return value
+
+
+def _default_path() -> Path:
+    return Path(os.environ.get("YASINAI_PROVIDER_CONFIG", "~/.config/yasinai/providers.json")).expanduser()
+
+
+def _master_key() -> str:
+    key = os.environ.get("YASINAI_MASTER_KEY")
+    if not key:
+        raise ProviderConfigError("Set YASINAI_MASTER_KEY before configuring providers")
+    return key
+
+
+class ProviderStore:
+    """Encrypted on-disk store for user-defined provider profiles."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or _default_path()
+        self.engine = EncryptionEngine()
+
+    def _read(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"providers": {}, "default": None}
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ProviderConfigError("Provider configuration cannot be read") from exc
+        if not isinstance(data, dict) or not isinstance(data.get("providers", {}), dict):
+            raise ProviderConfigError("Provider configuration is invalid")
+        return data
+
+    def _write(self, data: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        try:
+            os.chmod(self.path, 0o600)
+        except OSError:
+            pass
+
+    def list(self) -> list[dict[str, Any]]:
+        data = self._read()
+        return [
+            {
+                "name": name,
+                "base_url": item["base_url"],
+                "model": item["model"],
+                "default": name == data.get("default"),
+            }
+            for name, item in data["providers"].items()
+        ]
+
+    def get(self, name: str) -> dict[str, str] | None:
+        item = self._read()["providers"].get(name)
+        if item is None:
+            return None
+        try:
+            key = self.engine.decrypt(item["api_key_encrypted"], _master_key())
+        except (KeyError, ValueError) as exc:
+            raise ProviderConfigError("Stored provider credentials cannot be decrypted") from exc
+        return {
+            "name": name,
+            "base_url": item["base_url"],
+            "model": item["model"],
+            "api_key": key,
+        }
+
+    def save(self, *, name: str, base_url: str, model: str, api_key: str, make_default: bool = False) -> None:
+        name = name.strip()
+        model = model.strip()
+        if not name:
+            raise ProviderConfigError("Provider name must not be empty")
+        if not model:
+            raise ProviderConfigError("Model must not be empty")
+        if not api_key:
+            raise ProviderConfigError("API key must not be empty")
+        normalized = validate_base_url(base_url)
+        data = self._read()
+        data["providers"][name] = {
+            "base_url": normalized,
+            "model": model,
+            "api_key_encrypted": self.engine.encrypt(api_key, _master_key()),
+        }
+        if make_default or not data.get("default"):
+            data["default"] = name
+        self._write(data)
+
+    def remove(self, name: str) -> bool:
+        data = self._read()
+        if name not in data["providers"]:
+            return False
+        del data["providers"][name]
+        if data.get("default") == name:
+            data["default"] = next(iter(data["providers"]), None)
+        self._write(data)
+        return True
+
+    def use(self, name: str) -> None:
+        data = self._read()
+        if name not in data["providers"]:
+            raise ProviderConfigError(f"Provider '{name}' is not configured")
+        data["default"] = name
+        self._write(data)
+
+    def default(self) -> dict[str, str] | None:
+        data = self._read()
+        name = data.get("default")
+        return self.get(name) if name else None

--- a/yasinai/providers/factory.py
+++ b/yasinai/providers/factory.py
@@ -1,11 +1,9 @@
-"""
-Provider factory helpers — register default adapters into a registry.
-
-Does not import any third-party SDK at module level.
-"""
+"""Provider factory helpers — register built-in and runtime providers."""
 from __future__ import annotations
 
 from yasinai.providers.anthropic_provider import AnthropicProvider
+from yasinai.providers.config_store import ProviderConfigError, ProviderStore
+from yasinai.providers.generic_openai import GenericOpenAIProvider
 from yasinai.providers.local_provider import LocalProvider
 from yasinai.providers.openai_provider import OpenAIProvider
 from yasinai.providers.registry import ProviderRegistry
@@ -17,18 +15,38 @@ def register_default_providers(
     include_local: bool = True,
     include_openai: bool = True,
     include_anthropic: bool = True,
+    include_configured: bool = True,
     overwrite: bool = False,
 ) -> ProviderRegistry:
-    """
-    Register built-in providers. Availability is determined at call time
-    via each provider's ``is_available()`` (env keys).
-    """
+    """Register built-in providers and optional user-configured providers."""
     if include_local:
         registry.register(LocalProvider(), overwrite=overwrite)
     if include_openai:
         registry.register(OpenAIProvider(), overwrite=overwrite)
     if include_anthropic:
         registry.register(AnthropicProvider(), overwrite=overwrite)
+
+    if include_configured:
+        try:
+            store = ProviderStore()
+            for item in store.list():
+                config = store.get(item["name"])
+                if config is None:
+                    continue
+                registry.register(
+                    GenericOpenAIProvider(
+                        name=config["name"],
+                        base_url=config["base_url"],
+                        api_key=config["api_key"],
+                        default_model=config["model"],
+                    ),
+                    overwrite=overwrite,
+                )
+        except ProviderConfigError:
+            # Configured providers are optional. Existing env-based providers
+            # must continue to work when no master key/configuration exists.
+            pass
+
     return registry
 
 

--- a/yasinai/providers/generic_openai.py
+++ b/yasinai/providers/generic_openai.py
@@ -1,0 +1,62 @@
+"""Generic OpenAI-compatible provider adapter.
+
+This adapter deliberately knows nothing about a specific gateway.  A caller
+supplies the provider name, base URL, API key, and model at runtime.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from yasinai.providers.base import GenerationRequest, GenerationResponse, ProviderCapability, ProviderInfo
+from yasinai.providers.openai_provider import HttpTransport, OpenAIProvider
+
+
+class GenericOpenAIProvider(OpenAIProvider):
+    """Runtime-configured provider for OpenAI-compatible chat APIs."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        api_key: str,
+        base_url: str,
+        default_model: str,
+        transport: HttpTransport | None = None,
+    ) -> None:
+        if not name.strip():
+            raise ValueError("Provider name must not be empty")
+        if not api_key:
+            raise ValueError("API key must not be empty")
+        if not default_model.strip():
+            raise ValueError("Model must not be empty")
+        super().__init__(
+            api_key=api_key,
+            base_url=base_url,
+            default_model=default_model,
+            transport=transport,
+        )
+        self._provider_name = name.strip()
+
+    @property
+    def info(self) -> ProviderInfo:
+        return ProviderInfo(
+            name=self._provider_name,
+            version="1.0.0",
+            capabilities=[ProviderCapability.GENERATION, ProviderCapability.CHAT],
+            model_ids=[self._default_model],
+            metadata={"base_url": self._base_url, "protocol": "openai-chat-completions"},
+        )
+
+    def _generate(self, request: GenerationRequest) -> GenerationResponse:
+        response = super()._generate(request)
+        return replace(response, provider=self._provider_name)
+
+    def public_config(self) -> dict[str, Any]:
+        """Return non-secret provider metadata suitable for display."""
+        return {
+            "name": self._provider_name,
+            "base_url": self._base_url,
+            "model": self._default_model,
+            "protocol": "openai-chat-completions",
+        }


### PR DESCRIPTION
## Summary

Implements #183 with a runtime-configurable OpenAI-compatible provider.

### Included
- Generic provider adapter using runtime provider name, Base URL, API key and model
- Encrypted persistent provider configuration using existing AES-256-GCM security engine
- `yasin provider setup/list/use/test/remove` CLI
- Multiple provider profiles and default selection
- Secure Base URL validation
- Runtime loading of configured providers into the existing provider registry
- Tests for adapter, storage/security, validation and CLI parsing
- Documentation for setup and security

### Compatibility
- Existing Local/OpenAI/Anthropic providers remain registered as before
- No provider-specific Iranian gateway code
- Existing public GenerationService/contracts remain the consumer interface

Closes #183