### PR TITLE
feat: implement v1 AI capability service contract

### DIFF
--- a/api_service/__init__.py
+++ b/api_service/__init__.py
@@ -1,7 +1,21 @@
 """Public API/service layer for YasinAI."""
 
 from .app import APIService, create_service
+from .capability import CAPABILITIES_PATH, CONTRACT_VERSION, GENERATION_PATH, create_capability_service
 from .errors import APIError, AuthenticationError, AuthorizationError, ValidationError
 from .models import HealthResponse, ServiceResponse
 
-__all__ = ["APIError", "APIService", "AuthenticationError", "AuthorizationError", "HealthResponse", "ServiceResponse", "ValidationError", "create_service"]
+__all__ = [
+    "APIError",
+    "APIService",
+    "AuthenticationError",
+    "AuthorizationError",
+    "CAPABILITIES_PATH",
+    "CONTRACT_VERSION",
+    "GENERATION_PATH",
+    "HealthResponse",
+    "ServiceResponse",
+    "ValidationError",
+    "create_capability_service",
+    "create_service",
+]

--- a/api_service/capability.py
+++ b/api_service/capability.py
@@ -1,0 +1,120 @@
+"""Versioned Yasin-AI capability service contract.
+
+This module is the transport-neutral public boundary used by adapters such as
+HTTP, CLI, or in-process integration clients. Provider implementations remain
+private to Yasin-AI.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from yasinai.contracts import GenerationRequest
+from yasinai.services.generation_service import GenerationService
+
+from .app import APIService
+from .errors import ValidationError
+
+CONTRACT_VERSION = "v1"
+GENERATION_PATH = f"/{CONTRACT_VERSION}/generation"
+CAPABILITIES_PATH = f"/{CONTRACT_VERSION}/capabilities"
+
+
+def create_capability_service(
+    *,
+    generation: GenerationService | None = None,
+    name: str = "yasinai",
+    version: str = "1.1.4",
+) -> APIService:
+    """Create an API service exposing the stable v1 capability boundary."""
+    generation_service = generation if generation is not None else GenerationService()
+    service = APIService(name=name, version=version)
+
+    def capabilities(_: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "service": name,
+            "version": version,
+            "capabilities": ["generation"],
+        }
+
+    def generate(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        if not isinstance(payload, Mapping):
+            raise ValidationError("request body must be an object")
+
+        request = GenerationRequest(
+            prompt=_required_string(payload, "prompt"),
+            model=_optional_string(payload, "model"),
+            provider=_optional_string(payload, "provider"),
+            system_prompt=_optional_string(payload, "system_prompt"),
+            max_tokens=_bounded_int(payload, "max_tokens", 1, GenerationRequest.MAX_TOKENS_LIMIT, 1024),
+            temperature=_bounded_float(payload, "temperature", 0.0, 2.0, 0.7),
+            stop_sequences=_string_list(payload, "stop_sequences"),
+            metadata=_metadata(payload.get("metadata")),
+        )
+        result = generation_service.generate(request)
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "success": result.success,
+            "text": result.text,
+            "model": result.model,
+            "provider": result.provider,
+            "input_tokens": result.input_tokens,
+            "output_tokens": result.output_tokens,
+            "finish_reason": result.finish_reason,
+            "error": result.error,
+        }
+
+    service.add_route("GET", CAPABILITIES_PATH, capabilities)
+    service.add_route("POST", GENERATION_PATH, generate)
+    return service
+
+
+def _required_string(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"'{key}' must be a non-empty string")
+    return value
+
+
+def _optional_string(payload: Mapping[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"'{key}' must be a non-empty string when provided")
+    return value
+
+
+def _bounded_int(
+    payload: Mapping[str, Any], key: str, minimum: int, maximum: int, default: int
+) -> int:
+    value = payload.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= maximum:
+        raise ValidationError(f"'{key}' must be an integer between {minimum} and {maximum}")
+    return value
+
+
+def _bounded_float(
+    payload: Mapping[str, Any], key: str, minimum: float, maximum: float, default: float
+) -> float:
+    value = payload.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not minimum <= value <= maximum:
+        raise ValidationError(f"'{key}' must be a number between {minimum} and {maximum}")
+    return float(value)
+
+
+def _string_list(payload: Mapping[str, Any], key: str) -> list[str]:
+    value = payload.get(key, [])
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise ValidationError(f"'{key}' must be a list of strings")
+    return list(value)
+
+
+def _metadata(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValidationError("'metadata' must be an object")
+    return dict(value)

--- a/docs/AI_CAPABILITY_CONTRACT_V1.md
+++ b/docs/AI_CAPABILITY_CONTRACT_V1.md
@@ -1,0 +1,65 @@
+# Yasin-AI Capability Contract v1
+
+This document defines the first stable, transport-neutral public boundary for ecosystem consumers.
+
+## Contract identity
+
+- Contract: `v1`
+- Service: `yasinai`
+- Current implementation: `1.1.4`
+- Private provider, storage, and service implementation modules are not part of the contract.
+
+## Capabilities
+
+`GET /v1/capabilities` returns the version and currently exposed capability names.
+
+The initial capability is `generation`.
+
+## Generation
+
+`POST /v1/generation`
+
+Request fields:
+
+- `prompt` — required non-empty string
+- `model` — optional model identifier
+- `provider` — optional provider identifier
+- `system_prompt` — optional system instruction
+- `max_tokens` — integer from 1 to 32000; default 1024
+- `temperature` — number from 0.0 to 2.0; default 0.7
+- `stop_sequences` — optional list of strings
+- `metadata` — optional object for caller context
+
+Response fields:
+
+- `contract_version`
+- `success`
+- `text`
+- `model`
+- `provider`
+- `input_tokens`
+- `output_tokens`
+- `finish_reason`
+- `error`
+
+## Error semantics
+
+Malformed requests return status `400` with a safe `error` message. Unexpected handler failures return status `500` with `internal server error`; implementation details are not exposed.
+
+Provider failures are represented by the existing `GenerationResult` contract and do not expose credentials or provider internals.
+
+## Compatibility
+
+Consumers must depend on the public contract and adapters only. They must not import `yasinai.providers`, private service internals, SQLite internals, or provider SDKs.
+
+New fields may be added compatibly. Existing required field meanings and validation must not be changed within v1 without an explicit compatibility decision.
+
+## Transport
+
+The contract is transport-neutral. HTTP, CLI, and other transports may map to the same API service boundary without changing capability semantics.
+
+## Security
+
+Authentication and authorization are transport/deployment concerns and must be enforced by the concrete external adapter. The capability service itself must never treat caller-supplied metadata as authorization.
+
+No credentials are required for deterministic contract tests.

--- a/tests/test_capability_service_contract.py
+++ b/tests/test_capability_service_contract.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from yasinai.contracts import GenerationResult
+from api_service import CAPABILITIES_PATH, CONTRACT_VERSION, GENERATION_PATH, create_capability_service
+
+
+class FakeGenerationService:
+    def __init__(self) -> None:
+        self.requests = []
+
+    def generate(self, request):
+        self.requests.append(request)
+        return GenerationResult(
+            success=True,
+            text="generated",
+            model=request.model or "fake-model",
+            provider=request.provider or "fake",
+            input_tokens=2,
+            output_tokens=1,
+            finish_reason="stop",
+        )
+
+
+def test_capabilities_are_versioned_and_public() -> None:
+    service = create_capability_service(generation=FakeGenerationService())
+
+    response = service.dispatch("GET", CAPABILITIES_PATH)
+
+    assert response.status == 200
+    assert response.data == {
+        "contract_version": CONTRACT_VERSION,
+        "service": "yasinai",
+        "version": "1.1.4",
+        "capabilities": ["generation"],
+    }
+
+
+def test_generation_contract_maps_to_generation_service() -> None:
+    fake = FakeGenerationService()
+    service = create_capability_service(generation=fake)
+
+    response = service.dispatch(
+        "POST",
+        GENERATION_PATH,
+        {
+            "prompt": "hello",
+            "model": "fake-model",
+            "provider": "fake",
+            "max_tokens": 64,
+            "temperature": 0.2,
+            "metadata": {"request_id": "test-1"},
+        },
+    )
+
+    assert response.status == 200
+    assert response.data["contract_version"] == "v1"
+    assert response.data["success"] is True
+    assert response.data["text"] == "generated"
+    assert fake.requests[0].prompt == "hello"
+    assert fake.requests[0].model == "fake-model"
+    assert fake.requests[0].metadata == {"request_id": "test-1"}
+
+
+def test_generation_rejects_invalid_payload_without_calling_service() -> None:
+    fake = FakeGenerationService()
+    service = create_capability_service(generation=fake)
+
+    response = service.dispatch("POST", GENERATION_PATH, {"prompt": ""})
+
+    assert response.status == 400
+    assert "prompt" in response.data["error"]
+    assert fake.requests == []
+
+
+def test_generation_rejects_out_of_range_values() -> None:
+    fake = FakeGenerationService()
+    service = create_capability_service(generation=fake)
+
+    response = service.dispatch(
+        "POST",
+        GENERATION_PATH,
+        {"prompt": "hello", "temperature": 2.1},
+    )
+
+    assert response.status == 400
+    assert "temperature" in response.data["error"]
+    assert fake.requests == []
+
+
+def test_health_remains_available_under_capability_service() -> None:
+    service = create_capability_service(generation=FakeGenerationService())
+
+    response = service.dispatch("GET", "/health")
+
+    assert response.status == 200
+    assert response.data == {
+        "status": "ok",
+        "service": "yasinai",
+        "version": "1.1.4",
+    }


### PR DESCRIPTION
Closes #185

Implements the first stable transport-neutral v1 AI capability boundary required by YASIN-DOCS ADR-001.

- adds versioned capabilities and generation routes
- validates contract inputs and preserves safe error semantics
- keeps provider implementations behind Yasin-AI internals
- adds deterministic contract tests
- documents the public contract and compatibility rules